### PR TITLE
JSON conversion methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release Versions:
 ## Upcoming changes (in development)
 
 - Python bindings for clproto (#204)
+- JSON conversion support for clproto (#205)
 
 ## 4.0.0
 

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -32,6 +32,16 @@ public:
 };
 
 /**
+ * @class JsonParsingException
+ * @brief A JsonParsingException is raised whenever a
+ * JSON conversion operation fails due to invalid encoding.
+ */
+class JsonParsingException : public std::runtime_error {
+public:
+  explicit JsonParsingException(const std::string& msg);
+};
+
+/**
  * @enum MessageType
  * @brief The MessageType enumeration contains the possible
  * message types in the clproto.
@@ -118,9 +128,9 @@ std::string encode(const T& obj);
 /**
  * @brief Decode a serialized binary string from
  * wire format into a control libraries object instance.
- * Throws an exception if the message cannot be decoded
+ * @details Throws an exception if the message cannot be decoded
  * into the desired type.
- * @tparam The desired control libraries object type
+ * @tparam T The desired control libraries object type
  * @param msg The serialized binary string to decode
  * @return A new instance of the control libraries object
  */
@@ -130,7 +140,7 @@ T decode(const std::string& msg);
 /**
  * @brief Exception safe decoding of a serialized binary string
  * wire format into a control libraries object instance.
- * It modifies the object by reference if the decoding is
+ * @details It modifies the object by reference if the decoding is
  * successful, and leaves it unmodified otherwise.
  * @tparam T The desired control libraries object type
  * @param msg The serialized binary string to decode
@@ -168,4 +178,47 @@ void pack_fields(const std::vector<std::string>& fields, char* data);
  */
 std::vector<std::string> unpack_fields(const char* data);
 
+/**
+ * @brief Convert a serialized binary string from
+ * wire format into a JSON formatted state message description.
+ * @param msg The serialized binary string to decode
+ * @return The JSON formatted state message description
+ */
+std::string to_json(const std::string& msg);
+
+/**
+ * @brief Convert a control libraries object into
+ * into a JSON formatted state message description.
+ * @tparam T The provided control libraries object type
+ * @param obj The control libraries object to encode
+ * @return The JSON formatted state message description
+ */
+template<typename T>
+std::string to_json(const T& obj) {
+  return to_json(encode<T>(obj));
+}
+
+/**
+ * @brief Convert a JSON formatted state message description
+ * into a serialized binary string representation (wire format).
+ * @details Throws an exception if the message cannot be decoded
+ * into the desired type.
+ * @param json The JSON formatted state message description
+ * @return The serialized binary string encoding
+ */
+std::string from_json(const std::string& json);
+
+/**
+ * @brief Convert a JSON formatted state message description
+ * into a control libraries object instance.
+ * @details Throws an exception if the message cannot be
+ * converted into the desired type.
+ * @tparam T The desired control libraries object type
+ * @param json The JSON formatted state message description
+ * @return A new instance of the control libraries object
+ */
+template<typename T>
+T from_json(const std::string& json) {
+  return decode<T>(from_json(json));
+}
 }

--- a/protocol/clproto_cpp/test/tests/test_json.cpp
+++ b/protocol/clproto_cpp/test/tests/test_json.cpp
@@ -14,7 +14,7 @@ TEST(JsonProtoTest, JsonToFromBinary) {
   ASSERT_TRUE(clproto::check_message_type(msg) == clproto::CARTESIAN_STATE_MESSAGE);
 
   auto json = clproto::to_json(msg);
-  EXPECT_NE(json.size(), 0);
+  EXPECT_GT(json.size(), 2);  // empty JSON would be "{}"
   auto msg2 = clproto::from_json(json);
 
   CartesianState recv_state;
@@ -30,6 +30,7 @@ TEST(JsonProtoTest, JsonToFromObject) {
   auto send_state = CartesianState::Random("A", "B");
 
   auto json = clproto::to_json(send_state);
+  EXPECT_GT(json.size(), 2);  // empty JSON would be "{}"
   auto recv_state = clproto::from_json<CartesianState>(json);
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());

--- a/protocol/clproto_cpp/test/tests/test_json.cpp
+++ b/protocol/clproto_cpp/test/tests/test_json.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/robot/JointState.hpp>
+
+#include "clproto.h"
+
+using namespace state_representation;
+
+TEST(JsonProtoTest, JsonToFromBinary) {
+  auto send_state = CartesianState::Random("A", "B");
+  std::string msg = clproto::encode(send_state);
+  ASSERT_TRUE(clproto::is_valid(msg));
+  ASSERT_TRUE(clproto::check_message_type(msg) == clproto::CARTESIAN_STATE_MESSAGE);
+
+  auto json = clproto::to_json(msg);
+  EXPECT_NE(json.size(), 0);
+  auto msg2 = clproto::from_json(json);
+
+  CartesianState recv_state;
+  EXPECT_NO_THROW(clproto::decode<CartesianState>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
+  EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
+}
+
+TEST(JsonProtoTest, JsonToFromObject) {
+  auto send_state = CartesianState::Random("A", "B");
+
+  auto json = clproto::to_json(send_state);
+  auto recv_state = clproto::from_json<CartesianState>(json);
+
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
+  EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
+}
+
+TEST(JsonProtoTest, JsonToFromInvalid) {
+  auto json = clproto::to_json(CartesianState::Random("A", "B"));
+
+  EXPECT_NO_THROW(clproto::from_json<CartesianState>(json));
+  EXPECT_THROW(clproto::from_json<CartesianState>("definitely not json"), clproto::JsonParsingException);
+  EXPECT_THROW(clproto::from_json("definitely not json"), clproto::JsonParsingException);
+
+  // valid JSON of the wrong state type should instead throw a decoding exception
+  EXPECT_THROW(clproto::from_json<JointState>(json), clproto::DecodingException);
+
+  EXPECT_THROW(clproto::to_json(std::string("definitely not binary encoded data")), clproto::JsonParsingException);
+}
+
+/* If a to_json template is invoked that is not implemented in clproto,
+ * there will be a linker error "undefined reference" at compile time.
+ * Of course, it's not really possible to test this at run-time.
+PSEUDO_TEST(JsonProtoTest, JsonToInvalidObject) {
+  foo::Object invalid_object;
+
+  EXPECT_LINKER_ERROR(clproto::to_json(invalid_object));
+}
+*/

--- a/protocol/clproto_cpp/test/tests/test_messages.cpp
+++ b/protocol/clproto_cpp/test/tests/test_messages.cpp
@@ -6,7 +6,7 @@
 
 using namespace state_representation;
 
-TEST(CartesianProtoTest, EncodeDecodeState) {
+TEST(MessageProtoTest, EncodeDecodeState) {
   auto send_state = State(StateType::STATE, "A", false);
   std::string msg = clproto::encode(send_state);
   EXPECT_TRUE(clproto::is_valid(msg));
@@ -21,7 +21,7 @@ TEST(CartesianProtoTest, EncodeDecodeState) {
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
 }
 
-TEST(CartesianProtoTest, DecodeInvalidString) {
+TEST(MessageProtoTest, DecodeInvalidString) {
   std::string dummy_msg = "hello world";
 
   EXPECT_FALSE(clproto::is_valid(dummy_msg));

--- a/protocol/clproto_cpp/test/tests/test_parameter_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_parameter_proto.cpp
@@ -6,7 +6,7 @@
 
 using namespace state_representation;
 
-TEST(CartesianProtoTest, EncodeDecodeParameterDouble) {
+TEST(ParameterProtoTest, EncodeDecodeParameterDouble) {
   double value = 1.0;
 
   auto send_state = Parameter("A", value);
@@ -23,7 +23,7 @@ TEST(CartesianProtoTest, EncodeDecodeParameterDouble) {
   EXPECT_EQ(send_state.get_value(), recv_state.get_value());
 }
 
-TEST(CartesianProtoTest, EncodeDecodeParameterDoubleArray) {
+TEST(ParameterProtoTest, EncodeDecodeParameterDoubleArray) {
   std::vector<double> value = {1.0, 2.0, 3.0};
 
   auto send_state = Parameter("A", value);
@@ -43,7 +43,7 @@ TEST(CartesianProtoTest, EncodeDecodeParameterDoubleArray) {
   }
 }
 
-TEST(CartesianProtoTest, EncodeDecodeParameterBool) {
+TEST(ParameterProtoTest, EncodeDecodeParameterBool) {
   bool value = true;
 
   auto send_state = Parameter("A", value);
@@ -60,7 +60,7 @@ TEST(CartesianProtoTest, EncodeDecodeParameterBool) {
   EXPECT_EQ(send_state.get_value(), recv_state.get_value());
 }
 
-TEST(CartesianProtoTest, EncodeDecodeParameterBoolArray) {
+TEST(ParameterProtoTest, EncodeDecodeParameterBoolArray) {
   std::vector<bool> value = {true, false, true, false};
 
   auto send_state = Parameter("A", value);
@@ -80,7 +80,7 @@ TEST(CartesianProtoTest, EncodeDecodeParameterBoolArray) {
   }
 }
 
-TEST(CartesianProtoTest, EncodeDecodeParameterString) {
+TEST(ParameterProtoTest, EncodeDecodeParameterString) {
   std::string value = "value";
 
   auto send_state = Parameter("A", value);
@@ -97,7 +97,7 @@ TEST(CartesianProtoTest, EncodeDecodeParameterString) {
   EXPECT_STREQ(send_state.get_value().c_str(), recv_state.get_value().c_str());
 }
 
-TEST(CartesianProtoTest, EncodeDecodeParameterStringArray) {
+TEST(ParameterProtoTest, EncodeDecodeParameterStringArray) {
   std::vector<std::string> value = {"value 1", "value 2", "value 3"};
 
   auto send_state = Parameter("A", value);
@@ -117,7 +117,7 @@ TEST(CartesianProtoTest, EncodeDecodeParameterStringArray) {
   }
 }
 
-TEST(CartesianProtoTest, EncodeDecodeParameterVector) {
+TEST(ParameterProtoTest, EncodeDecodeParameterVector) {
   Eigen::VectorXd value(5);
   value << 1.0, 2.0, 3.0, 4.0, 5.0;
 
@@ -138,7 +138,7 @@ TEST(CartesianProtoTest, EncodeDecodeParameterVector) {
   }
 }
 
-TEST(CartesianProtoTest, EncodeDecodeParameterMatrix) {
+TEST(ParameterProtoTest, EncodeDecodeParameterMatrix) {
   Eigen::MatrixXd value(2, 3);
   value << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
 

--- a/python/README.md
+++ b/python/README.md
@@ -87,10 +87,12 @@ Bindings exist for the following modules, classes and methods:
   - `is_valid(msg)`
   - `check_message_type(msg)`
   - `check_parameter_message_type(msg)`
-  - `encode(obj, type)`
-  - `decode(msg)`
+  - `msg = encode(obj, type)`
+  - `obj = decode(msg)`
   - `pack_fields(encoded_fields)`
   - `unpack_fields(packet)`
+  - `json = to_json(msg)`
+  - `msg = from_json(json)`
 
 ## About
 

--- a/python/source/clproto/bind_clproto.cpp
+++ b/python/source/clproto/bind_clproto.cpp
@@ -143,7 +143,10 @@ void methods(py::module_& m) {
       default:
         return py::none();
     }
-  }, "Decode a serialized binary string from wire format into a control libraries object instance.", "message"_a);
+  }, "Decode a serialized binary string from wire format into a control libraries object instance.", "msg"_a);
+
+  m.def("to_json", [](const std::string& msg) { return to_json(msg); }, "Convert a serialized binary string from wire format into a JSON formatted state message description", "msg"_a);
+  m.def("from_json", [](const std::string& json) -> py::bytes { return from_json(json); }, "Convert a JSON formatted state message description into a serialized binary string representation (wire format).", "msg"_a);
 }
 
 void bind_clproto(py::module_& m) {

--- a/python/test/test_clproto.py
+++ b/python/test/test_clproto.py
@@ -25,6 +25,22 @@ class TestClprotoPackUnpack(unittest.TestCase):
         self.assertListEqual(objects[1].get_names(), decoded_objects[1].get_names())
         self.assertAlmostEqual(sr.dist(objects[1], decoded_objects[1]), 0)
 
+class TestClprotoJSON(unittest.TestCase):
+    def test_to_from_json(self):
+        reference_object = sr.CartesianState.Random("A", "B")
+        message_type = clproto.MessageType.CARTESIAN_STATE_MESSAGE
+        msg = clproto.encode(reference_object, message_type)
+        json = clproto.to_json(msg)
+        msg2 = clproto.from_json(json)
+        self.assertTrue(clproto.is_valid(msg2))
+        self.assertEqual(clproto.check_message_type(msg2), message_type)
+        decoded_object = clproto.decode(msg)
+        self.assertIsInstance(decoded_object, type(reference_object))
+
+        self.assertEqual(reference_object.get_name(), decoded_object.get_name())
+        self.assertEqual(reference_object.get_reference_frame(), decoded_object.get_reference_frame())
+        self.assertAlmostEqual(sr.dist(reference_object, decoded_object), 0)
+
 class TestClprotoState(unittest.TestCase):
     def state_class_assertions(self, reference_object, message_type):
         object_type = type(reference_object)


### PR DESCRIPTION
This is something that came to mind while talking to @MichaelBombile earlier. It would be nice to be able to generate logs from control library types that are easily and portably machine-readable but preferably also human-readable. The binary encoding provided by clproto is excellent for its compactness, allowing very efficient network communication, but it is neither human-readable nor particularly portable without clproto decoding libraries in C++ or Python.

The google protobuf utilities allow for conversion between binary encoding and JSON format (or between proto message types and JSON), providing the message type is available. This would normally require either exposing the message classes in the intermediate binding headers or else some form of introspection to know what class to parse.
 
But, thanks to the design choice of using a fixed message type (state_representation::proto::StateMessage) as the container for all messages, we can actually achieve this very easily.

The changes in this PR allow for the conversion between an encoded wire format and a JSON format, or even directly between a state object and the JSON formatted encoding.

As an example, the following three representations would now all be mutually transferrable 
```
# state object
A CartesianPose expressed in B frame
position: (0.59688, 0.823295, -0.604897)
orientation: (0.246242, -0.314924, -0.896867, 0.189256) <=> theta: 2.64399, axis: (-0.324929, -0.92536, 0.195269)

# binary encoding
A ��Ѩ��B	H3�9��?ܰ�(nX�?��f�Q[�&	u�>/ڄ�?	|��Ƿ'Կ���!����X>�9�?

# json encoding
{"cartesianPose":{"spatialState":{"state":{"name":"A","type":"CARTESIANSTATE","timestamp":"78533830663297"},"referenceFrame":"B"},"position":{"x":0.59688006695214657,"y":0.82329471587356862,"z":-0.60489726141323208},"orientation":{"w":0.24624182993742819,"vec":{"x":-0.31492418775692221,"y":-0.89686660657721839,"z":0.18925645870451685}}}}

```

---

* Add to_json and from_json methods to clproto to operate on encoded wire format or state objects direclty, allowing for more human-readable printing and logging

* Add JSON parsing exception for cases when JSON conversion fails

* Extend clproto tests to cover JSON utilities

* Minor refactor of test names

* Bind to_json and from_json methods from clproto in Python. Note that only the translation between wire format and JSON is defined, because the lack of templates makes automatic deduction of the desired conversion difficult. The python usage should simply be json = to_json(encode(obj, type) and decode(from_json(json))

* Test json methods

* Update CHANGELOG