### PR TITLE
Fix doc generation on release

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -5,6 +5,7 @@ on:
       - main
       - develop
   release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         shell: bash
         run: |
-          TAG="${GITHUB_REF#refs/heads/}"
+          TAG="${GITHUB_REF#refs-tags/}"
           TAG="${TAG/\//-}"
           mkdir -p doxygen/docs/versions
           sudo mv doxygen/docs/html doxygen/docs/versions/${TAG}


### PR DESCRIPTION
* Get the tagged version from the GITHUB_REF variable correctly by stripping `refs-tags/` instead of `refs/heads/`

* Only trigger docs build once on release publish, instead of multiple times (created, released, published)

---

Before I forget, here's a quick fix for the generation of documentation on release which failed [here](https://github.com/epfl-lasa/control-libraries/runs/3542379448?check_suite_focus=true).

Because it wasn't correctly stripping the `refs-tags/` prefix, the CI fails with
```console
mv: cannot move 'doxygen/docs/html' to 'doxygen/docs/versions/refs-tags/v4.0.0'
```

Now it will correctly strip and parse the doc directory as `doxygen/docs/versions/v4.0.0` instead.

I also made it so that it only generates when a release is published, so we don't invoke multiple generation actions when working on releases.

I already manually fixed the docs for the versioned releases so v4.0.0 is ready to look at (with `main` also mirroring the latest release)
https://epfl-lasa.github.io/control-libraries/