### PR TITLE
Handle empty states in clproto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Release Versions:
 
 - Python bindings for clproto (#204)
 - JSON conversion support for clproto (#205)
+- Support empty state objects in clproto (#207)
 
 ## 4.0.0
 

--- a/protocol/clproto_cpp/src/encoders.cpp
+++ b/protocol/clproto_cpp/src/encoders.cpp
@@ -46,6 +46,9 @@ proto::Quaterniond encoder(const Eigen::Quaterniond& quaternion) {
 proto::CartesianState encoder(const CartesianState& cartesian_state) {
   proto::CartesianState message;
   *message.mutable_spatial_state() = encoder(static_cast<SpatialState>(cartesian_state));
+  if (cartesian_state.is_empty()) {
+    return message;
+  }
   *message.mutable_position() = encoder(cartesian_state.get_position());
   *message.mutable_orientation() = encoder(cartesian_state.get_orientation());
   *message.mutable_linear_velocity() = encoder(cartesian_state.get_linear_velocity());
@@ -60,6 +63,9 @@ proto::CartesianState encoder(const CartesianState& cartesian_state) {
 proto::Jacobian encoder(const Jacobian& jacobian) {
   proto::Jacobian message;
   *message.mutable_state() = encoder(static_cast<State>(jacobian));
+  if (!jacobian.is_empty()) {
+    return message;
+  }
   *message.mutable_joint_names() = {jacobian.get_joint_names().begin(), jacobian.get_joint_names().end()};
   message.set_frame(jacobian.get_frame());
   message.set_reference_frame(jacobian.get_reference_frame());
@@ -72,6 +78,9 @@ proto::Jacobian encoder(const Jacobian& jacobian) {
 proto::JointState encoder(const JointState& joint_state) {
   proto::JointState message;
   *message.mutable_state() = encoder(static_cast<State>(joint_state));
+  if (joint_state.is_empty()) {
+    return message;
+  }
   *message.mutable_joint_names() = {joint_state.get_names().begin(), joint_state.get_names().end()};
   *message.mutable_positions() = matrix_encoder(joint_state.get_positions());
   *message.mutable_velocities() = matrix_encoder(joint_state.get_velocities());

--- a/protocol/clproto_cpp/src/encoders.cpp
+++ b/protocol/clproto_cpp/src/encoders.cpp
@@ -63,7 +63,7 @@ proto::CartesianState encoder(const CartesianState& cartesian_state) {
 proto::Jacobian encoder(const Jacobian& jacobian) {
   proto::Jacobian message;
   *message.mutable_state() = encoder(static_cast<State>(jacobian));
-  if (!jacobian.is_empty()) {
+  if (jacobian.is_empty()) {
     return message;
   }
   *message.mutable_joint_names() = {jacobian.get_joint_names().begin(), jacobian.get_joint_names().end()};

--- a/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
@@ -85,3 +85,47 @@ TEST(CartesianProtoTest, EncodeDecodeCartesianWrench) {
   EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
   EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
 }
+
+TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianState) {
+  CartesianState empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  CartesianState recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<CartesianState>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianPose) {
+  CartesianPose empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  CartesianPose recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<CartesianPose>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianTwist) {
+  CartesianTwist empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  CartesianTwist recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<CartesianTwist>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianWrench) {
+  CartesianWrench empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  CartesianWrench recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<CartesianWrench>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}

--- a/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
@@ -35,6 +35,7 @@ TEST(CartesianProtoTest, EncodeDecodeCartesianState) {
   CartesianState recv_state;
   EXPECT_NO_THROW(clproto::decode<CartesianState>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
@@ -50,6 +51,7 @@ TEST(CartesianProtoTest, EncodeDecodeCartesianPose) {
   CartesianPose recv_state;
   EXPECT_NO_THROW(clproto::decode<CartesianPose>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
@@ -65,6 +67,7 @@ TEST(CartesianProtoTest, EncodeDecodeCartesianTwist) {
   CartesianTwist recv_state;
   EXPECT_NO_THROW(clproto::decode<CartesianTwist>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
@@ -80,6 +83,7 @@ TEST(CartesianProtoTest, EncodeDecodeCartesianWrench) {
   CartesianWrench recv_state;
   EXPECT_NO_THROW(clproto::decode<CartesianWrench>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());

--- a/protocol/clproto_cpp/test/tests/test_joint_space_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_joint_space_proto.cpp
@@ -12,7 +12,7 @@
 using namespace state_representation;
 
 TEST(JointProtoTest, EncodeDecodeJacobian) {
-  auto send_state = Jacobian("robot", 3, "A", "B");
+  auto send_state = Jacobian::Random("robot", {"one", "two", "three"}, "A", "B");
   std::string msg = clproto::encode(send_state);
   EXPECT_TRUE(clproto::is_valid(msg));
   EXPECT_TRUE(clproto::check_message_type(msg) == clproto::JACOBIAN_MESSAGE);
@@ -20,8 +20,10 @@ TEST(JointProtoTest, EncodeDecodeJacobian) {
   Jacobian recv_state;
   EXPECT_NO_THROW(clproto::decode<Jacobian>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_STREQ(send_state.get_frame().c_str(), recv_state.get_frame().c_str());
   EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
   EXPECT_EQ(send_state.rows(), recv_state.rows());
   EXPECT_EQ(send_state.cols(), recv_state.cols());
@@ -42,6 +44,7 @@ TEST(JointProtoTest, EncodeDecodeJointState) {
   JointState recv_state;
   EXPECT_NO_THROW(clproto::decode<JointState>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   ASSERT_EQ(send_state.get_size(), recv_state.get_size());
@@ -60,6 +63,7 @@ TEST(JointProtoTest, EncodeDecodeJointPositions) {
   JointPositions recv_state;
   EXPECT_NO_THROW(clproto::decode<JointPositions>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   ASSERT_EQ(send_state.get_size(), recv_state.get_size());
@@ -78,6 +82,7 @@ TEST(JointProtoTest, EncodeDecodeJointVelocities) {
   JointVelocities recv_state;
   EXPECT_NO_THROW(clproto::decode<JointVelocities>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   ASSERT_EQ(send_state.get_size(), recv_state.get_size());
@@ -96,6 +101,7 @@ TEST(JointProtoTest, EncodeDecodeJointAccelerations) {
   JointAccelerations recv_state;
   EXPECT_NO_THROW(clproto::decode<JointAccelerations>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   ASSERT_EQ(send_state.get_size(), recv_state.get_size());
@@ -114,6 +120,7 @@ TEST(JointProtoTest, EncodeDecodeJointTorques) {
   JointTorques recv_state;
   EXPECT_NO_THROW(clproto::decode<JointTorques>(msg));
   EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
   ASSERT_EQ(send_state.get_size(), recv_state.get_size());

--- a/protocol/clproto_cpp/test/tests/test_joint_space_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_joint_space_proto.cpp
@@ -122,3 +122,69 @@ TEST(JointProtoTest, EncodeDecodeJointTorques) {
   }
   EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
 }
+
+TEST(JointProtoTest, EncodeDecodeEmptyJacobian) {
+  Jacobian empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  Jacobian recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<Jacobian>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(JointProtoTest, EncodeDecodeEmptyJointPositions) {
+  JointPositions empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  JointPositions recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<JointPositions>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(JointProtoTest, EncodeDecodeEmptyJointState) {
+  JointState empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  JointState recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<JointState>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(JointProtoTest, EncodeDecodeEmptyJointVelocities) {
+  JointVelocities empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  JointVelocities recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<JointVelocities>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(JointProtoTest, EncodeDecodeEmptyJointAccelerations) {
+  JointAccelerations empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  JointAccelerations recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<JointAccelerations>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(JointProtoTest, EncodeDecodeEmptyJointTorques) {
+  JointTorques empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  JointTorques recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<JointTorques>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}

--- a/protocol/clproto_cpp/test/tests/test_parameter_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_parameter_proto.cpp
@@ -160,3 +160,36 @@ TEST(ParameterProtoTest, EncodeDecodeParameterMatrix) {
     EXPECT_EQ(send_state.get_value()(index), recv_state.get_value()(index));
   }
 }
+
+TEST(ParameterProtoTest, EncodeDecodeEmptyParameterDouble) {
+  Parameter<double> empty_state("");
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  Parameter<double> recv_state("");
+  EXPECT_NO_THROW(recv_state = clproto::decode<Parameter<double>>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(ParameterProtoTest, EncodeDecodeEmptyParameterBool) {
+  Parameter<bool> empty_state("");
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  Parameter<bool> recv_state("");
+  EXPECT_NO_THROW(recv_state = clproto::decode<Parameter<bool>>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(ParameterProtoTest, EncodeDecodeEmptyParameterString) {
+  Parameter<std::string> empty_state("");
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+  Parameter<std::string> recv_state("");
+  EXPECT_NO_THROW(recv_state = clproto::decode<Parameter<std::string>>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
+}

--- a/python/test/test_clproto.py
+++ b/python/test/test_clproto.py
@@ -119,6 +119,7 @@ class TestClprotoJacobian(unittest.TestCase):
         self.assertIsInstance(obj2, sr.Jacobian)
         self.assertEqual(obj1.get_name(), obj2.get_name())
         self.assertEqual(obj1.get_frame(), obj2.get_frame())
+        self.assertEqual(obj1.get_reference_frame(), obj2.get_reference_frame())
         self.assertListEqual(obj1.get_joint_names(), obj2.get_joint_names())
         self.assertEqual(obj1.rows(), obj2.rows())
         self.assertEqual(obj1.cols(), obj2.cols())

--- a/source/state_representation/src/parameters/Parameter.cpp
+++ b/source/state_representation/src/parameters/Parameter.cpp
@@ -6,9 +6,7 @@
 namespace state_representation {
 template <>
 Parameter<double>::Parameter(const std::string& name) :
-    ParameterInterface(StateType::PARAMETER_DOUBLE, name) {
-  this->set_filled();
-}
+    ParameterInterface(StateType::PARAMETER_DOUBLE, name) {}
 
 template <>
 Parameter<double>::Parameter(const std::string& name, const double& value) :
@@ -105,6 +103,10 @@ Parameter<JointPositions>::Parameter(const std::string& name, const JointPositio
     ParameterInterface(StateType::PARAMETER_JOINTPOSITIONS, name), value(value) {
   this->set_filled();
 }
+
+template <>
+Parameter<Ellipsoid>::Parameter(const std::string& name) :
+    ParameterInterface(StateType::PARAMETER_ELLIPSOID, name) {}
 
 template <>
 Parameter<Ellipsoid>::Parameter(const std::string& name, const Ellipsoid& value) :

--- a/source/state_representation/src/parameters/Parameter.cpp
+++ b/source/state_representation/src/parameters/Parameter.cpp
@@ -105,10 +105,6 @@ Parameter<JointPositions>::Parameter(const std::string& name, const JointPositio
 }
 
 template <>
-Parameter<Ellipsoid>::Parameter(const std::string& name) :
-    ParameterInterface(StateType::PARAMETER_ELLIPSOID, name) {}
-
-template <>
 Parameter<Ellipsoid>::Parameter(const std::string& name, const Ellipsoid& value) :
     ParameterInterface(StateType::PARAMETER_ELLIPSOID, name), value(value) {
   this->set_filled();


### PR DESCRIPTION
Sometimes it is desirable to send an empty object as a message. These changes fix some bugs with Jacobian and Parameter, and add explicit behaviour to handle emptiness. 

---

* Explicitly support and test encoding and decoding empty state messages for joint, cartesian, jacobian and param

* Fix bug in Parameter which was setting filled on empty double constructor

* Add missing empty constructor for Parameter<Ellipsoid>