### PR TITLE
Add python bindings for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release Versions:
 - Add method to get a joint state by name or index of the joint,
   and to get the index of the joint by its name (#210)
 - Add possibility to have a ssh server for Python testing (#211)
+- Add Python bindings for Parameter class
 
 ## 4.0.0
 

--- a/python/dev-server.sh
+++ b/python/dev-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASE_IMAGE=controle-libraries/remote-development:latest
+BASE_IMAGE=control-libraries/remote-development:latest
 IMAGE_NAME=control-libraries/python/remote
 CONTAINER_NAME=control-libraries-python-ssh
 CONTAINER_HOSTNAME=control-libraries-python

--- a/python/source/state_representation/bind_parameters.cpp
+++ b/python/source/state_representation/bind_parameters.cpp
@@ -27,7 +27,98 @@ class ParameterContainer : public ParameterInterface {
 public:
   ParameterContainer(const std::string& name, const StateType& type) : ParameterInterface(type, name) {}
 
-  explicit ParameterContainer(const ParameterContainer& parameter) : ParameterInterface(parameter.get_type(), parameter.get_name()) {}
+  ParameterContainer(const std::string& name, const py::object& value, const StateType& type) :
+      ParameterInterface(type, name) {
+    set_value(value);
+  }
+
+  explicit ParameterContainer(const ParameterContainer& parameter) :
+      ParameterInterface(parameter.get_type(), parameter.get_name()) {}
+
+  void set_value(const py::object& value) {
+    switch(this->get_type()) {
+      case StateType::PARAMETER_INT:
+        values.int_value = value.cast<int>();
+        break;
+      case StateType::PARAMETER_INT_ARRAY:
+        values.int_array_value = value.cast<std::vector<int>>();
+        break;
+      case StateType::PARAMETER_DOUBLE:
+        values.double_value = value.cast<double>();
+        break;
+      case StateType::PARAMETER_DOUBLE_ARRAY:
+        values.double_array_value = value.cast<std::vector<double>>();
+        break;
+      case StateType::PARAMETER_BOOL:
+        values.bool_value = value.cast<bool>();
+        break;
+      case StateType::PARAMETER_BOOL_ARRAY:
+        values.bool_array_value = value.cast<std::vector<bool>>();
+        break;
+      case StateType::PARAMETER_STRING:
+        values.string_value = value.cast<std::string>();
+        break;
+      case StateType::PARAMETER_STRING_ARRAY:
+        values.string_array_value = value.cast<std::vector<std::string>>();
+        break;
+      case StateType::PARAMETER_CARTESIANSTATE:
+        values.cartesian_state = value.cast<CartesianState>();
+        break;
+      case StateType::PARAMETER_CARTESIANPOSE:
+        values.cartesian_pose = value.cast<CartesianPose>();
+        break;
+      case StateType::PARAMETER_JOINTSTATE:
+        values.joint_state = value.cast<JointState>();
+        break;
+      case StateType::PARAMETER_JOINTPOSITIONS:
+        values.joint_positions = value.cast<JointPositions>();
+        break;
+      case StateType::PARAMETER_MATRIX:
+        values.matrix_value = value.cast<Eigen::MatrixXd>();
+        break;
+      case StateType::PARAMETER_VECTOR:
+        values.vector_value = value.cast<Eigen::VectorXd>();
+        break;
+      default:
+        throw std::invalid_argument("This StateType is not a valid Parameter.");
+        break;
+    }
+  }
+
+  py::object get_value() {
+    switch (this->get_type()) {
+      case StateType::PARAMETER_INT:
+        return py::cast(values.int_value);
+      case StateType::PARAMETER_INT_ARRAY:
+        return py::cast(values.int_array_value);
+      case StateType::PARAMETER_DOUBLE:
+        return py::cast(values.double_value);
+      case StateType::PARAMETER_DOUBLE_ARRAY:
+        return py::cast(values.double_array_value);
+      case StateType::PARAMETER_BOOL:
+        return py::cast(values.bool_value);
+      case StateType::PARAMETER_BOOL_ARRAY:
+        return py::cast(values.bool_array_value);
+      case StateType::PARAMETER_STRING:
+        return py::cast(values.string_value);
+      case StateType::PARAMETER_STRING_ARRAY:
+        return py::cast(values.string_array_value);
+      case StateType::PARAMETER_CARTESIANSTATE:
+        return py::cast(values.cartesian_state);
+      case StateType::PARAMETER_CARTESIANPOSE:
+        return py::cast(values.cartesian_pose);
+      case StateType::PARAMETER_JOINTSTATE:
+        return py::cast(values.joint_state);
+      case StateType::PARAMETER_JOINTPOSITIONS:
+        return py::cast(values.joint_positions);
+      case StateType::PARAMETER_MATRIX:
+        return py::cast(values.matrix_value);
+      case StateType::PARAMETER_VECTOR:
+        return py::cast(values.vector_value);
+      default:
+        return py::none();
+    }
+  }
 
   ParameterValues values;
 };
@@ -43,91 +134,11 @@ void parameter(py::module_& m) {
   py::class_<ParameterContainer, ParameterInterface> c(m, "Parameter");
 
   c.def(py::init<const std::string&, const StateType&>(), "Constructor of a parameter with name and type", "name"_a, "type"_a);
+  c.def(py::init<const std::string&, const py::object&, const StateType&>(), "Constructor of a parameter with name, value and type", "name"_a, "value"_a, "type"_a);
   c.def(py::init<const ParameterContainer&>(), "Copy constructor from another Parameter", "parameter"_a);
 
-  c.def("set_value", [](ParameterContainer& parameter, const py::object& value) {
-    switch (parameter.get_type()) {
-      case StateType::PARAMETER_INT:
-        parameter.values.int_value = value.cast<int>();
-        break;
-      case StateType::PARAMETER_INT_ARRAY:
-        parameter.values.int_array_value = value.cast<std::vector<int>>();
-        break;
-      case StateType::PARAMETER_DOUBLE:
-        parameter.values.double_value = value.cast<double>();
-        break;
-      case StateType::PARAMETER_DOUBLE_ARRAY:
-        parameter.values.double_array_value = value.cast<std::vector<double>>();
-        break;
-      case StateType::PARAMETER_BOOL:
-        parameter.values.bool_value = value.cast<bool>();
-        break;
-      case StateType::PARAMETER_BOOL_ARRAY:
-        parameter.values.bool_array_value = value.cast<std::vector<bool>>();
-        break;
-      case StateType::PARAMETER_STRING:
-        parameter.values.string_value = value.cast<std::string>();
-        break;
-      case StateType::PARAMETER_STRING_ARRAY:
-        parameter.values.string_array_value = value.cast<std::vector<std::string>>();
-        break;
-      case StateType::PARAMETER_CARTESIANSTATE:
-        parameter.values.cartesian_state = value.cast<CartesianState>();
-        break;
-      case StateType::PARAMETER_CARTESIANPOSE:
-        parameter.values.cartesian_pose = value.cast<CartesianPose>();
-        break;
-      case StateType::PARAMETER_JOINTSTATE:
-        parameter.values.joint_state = value.cast<JointState>();
-        break;
-      case StateType::PARAMETER_JOINTPOSITIONS:
-        parameter.values.joint_positions = value.cast<JointPositions>();
-        break;
-      case StateType::PARAMETER_MATRIX:
-        parameter.values.matrix_value = value.cast<Eigen::MatrixXd>();
-        break;
-      case StateType::PARAMETER_VECTOR:
-        parameter.values.vector_value = value.cast<Eigen::VectorXd>();
-        break;
-      default:
-        break;
-    }
-  }, "Setter of the value attribute.", py::arg("value"));
-
-  c.def("get_value", [](const ParameterContainer& parameter) -> py::object {
-    switch (parameter.get_type()) {
-      case StateType::PARAMETER_INT:
-        return py::cast(parameter.values.int_value);
-      case StateType::PARAMETER_INT_ARRAY:
-        return py::cast(parameter.values.int_array_value);
-      case StateType::PARAMETER_DOUBLE:
-        return py::cast(parameter.values.double_value);
-      case StateType::PARAMETER_DOUBLE_ARRAY:
-        return py::cast(parameter.values.double_array_value);
-      case StateType::PARAMETER_BOOL:
-        return py::cast(parameter.values.bool_value);
-      case StateType::PARAMETER_BOOL_ARRAY:
-        return py::cast(parameter.values.bool_array_value);
-      case StateType::PARAMETER_STRING:
-        return py::cast(parameter.values.string_value);
-      case StateType::PARAMETER_STRING_ARRAY:
-        return py::cast(parameter.values.string_array_value);
-      case StateType::PARAMETER_CARTESIANSTATE:
-        return py::cast(parameter.values.cartesian_state);
-      case StateType::PARAMETER_CARTESIANPOSE:
-        return py::cast(parameter.values.cartesian_pose);
-      case StateType::PARAMETER_JOINTSTATE:
-        return py::cast(parameter.values.joint_state);
-      case StateType::PARAMETER_JOINTPOSITIONS:
-        return py::cast(parameter.values.joint_positions);
-      case StateType::PARAMETER_MATRIX:
-        return py::cast(parameter.values.matrix_value);
-      case StateType::PARAMETER_VECTOR:
-        return py::cast(parameter.values.vector_value);
-      default:
-        return py::none();
-    }
-  }, "Getter of the value attribute.");
+  c.def("get_value", &ParameterContainer::get_value, "Getter of the value attribute.");
+  c.def("set_value", &ParameterContainer::set_value, "Setter of the value attribute.", py::arg("value"));
 
   c.def("__repr__", [](const ParameterContainer& parameter) {
     std::stringstream buffer;

--- a/python/source/state_representation/bind_parameters.cpp
+++ b/python/source/state_representation/bind_parameters.cpp
@@ -7,6 +7,8 @@
 #include <state_representation/robot/JointPositions.hpp>
 
 struct ParameterValues {
+  int int_value;
+  std::vector<int> int_array_value;
   double double_value;
   std::vector<double> double_array_value;
   bool bool_value;
@@ -45,6 +47,12 @@ void parameter(py::module_& m) {
 
   c.def("set_value", [](ParameterContainer& parameter, const py::object& value) {
     switch (parameter.get_type()) {
+      case StateType::PARAMETER_INT:
+        parameter.values.int_value = value.cast<int>();
+        break;
+      case StateType::PARAMETER_INT_ARRAY:
+        parameter.values.int_array_value = value.cast<std::vector<int>>();
+        break;
       case StateType::PARAMETER_DOUBLE:
         parameter.values.double_value = value.cast<double>();
         break;
@@ -88,6 +96,10 @@ void parameter(py::module_& m) {
 
   c.def("get_value", [](const ParameterContainer& parameter) -> py::object {
     switch (parameter.get_type()) {
+      case StateType::PARAMETER_INT:
+        return py::cast(parameter.values.int_value);
+      case StateType::PARAMETER_INT_ARRAY:
+        return py::cast(parameter.values.int_array_value);
       case StateType::PARAMETER_DOUBLE:
         return py::cast(parameter.values.double_value);
       case StateType::PARAMETER_DOUBLE_ARRAY:
@@ -120,6 +132,16 @@ void parameter(py::module_& m) {
   c.def("__repr__", [](const ParameterContainer& parameter) {
     std::stringstream buffer;
     switch (parameter.get_type()) {
+      case StateType::PARAMETER_INT: {
+        Parameter<int> param(parameter.get_name(), parameter.values.int_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_INT_ARRAY: {
+        Parameter<std::vector<int>> param(parameter.get_name(), parameter.values.int_array_value);
+        buffer << param;
+        break;
+      }
       case StateType::PARAMETER_DOUBLE: {
         Parameter<double> param(parameter.get_name(), parameter.values.double_value);
         buffer << param;

--- a/python/source/state_representation/bind_parameters.cpp
+++ b/python/source/state_representation/bind_parameters.cpp
@@ -1,0 +1,193 @@
+#include "state_representation_bindings.h"
+
+#include <state_representation/State.hpp>
+#include <state_representation/parameters/ParameterInterface.hpp>
+#include <state_representation/parameters/Parameter.hpp>
+#include <state_representation/space/cartesian/CartesianPose.hpp>
+#include <state_representation/robot/JointPositions.hpp>
+
+struct ParameterValues {
+  double double_value;
+  std::vector<double> double_array_value;
+  bool bool_value;
+  std::vector<bool> bool_array_value;
+  std::string string_value;
+  std::vector<std::string> string_array_value;
+  CartesianState cartesian_state;
+  CartesianPose cartesian_pose;
+  JointState joint_state;
+  JointPositions joint_positions;
+  Eigen::MatrixXd matrix_value;
+  Eigen::VectorXd vector_value;
+};
+
+class ParameterContainer : public ParameterInterface {
+public:
+  ParameterContainer(const std::string& name, const StateType& type) : ParameterInterface(type, name) {}
+
+  explicit ParameterContainer(const ParameterContainer& parameter) : ParameterInterface(parameter.get_type(), parameter.get_name()) {}
+
+  ParameterValues values;
+};
+
+void parameter_interface(py::module_& m) {
+  py::class_<ParameterInterface, State> c(m, "ParameterInterface");
+
+  c.def(py::init<const StateType&, const std::string&>(), "Constructor with parameter name and type of the parameter", "type"_a, "name"_a);
+  c.def(py::init<const ParameterInterface&>(), "Copy constructor from another ParameterInterface", "parameter"_a);
+}
+
+void parameter(py::module_& m) {
+  py::class_<ParameterContainer, ParameterInterface> c(m, "Parameter");
+
+  c.def(py::init<const std::string&, const StateType&>(), "Constructor of a parameter with name and type", "name"_a, "type"_a);
+  c.def(py::init<const ParameterContainer&>(), "Copy constructor from another Parameter", "parameter"_a);
+
+  c.def("set_value", [](ParameterContainer& parameter, const py::object& value) {
+    switch (parameter.get_type()) {
+      case StateType::PARAMETER_DOUBLE:
+        parameter.values.double_value = value.cast<double>();
+        break;
+      case StateType::PARAMETER_DOUBLE_ARRAY:
+        parameter.values.double_array_value = value.cast<std::vector<double>>();
+        break;
+      case StateType::PARAMETER_BOOL:
+        parameter.values.bool_value = value.cast<bool>();
+        break;
+      case StateType::PARAMETER_BOOL_ARRAY:
+        parameter.values.bool_array_value = value.cast<std::vector<bool>>();
+        break;
+      case StateType::PARAMETER_STRING:
+        parameter.values.string_value = value.cast<std::string>();
+        break;
+      case StateType::PARAMETER_STRING_ARRAY:
+        parameter.values.string_array_value = value.cast<std::vector<std::string>>();
+        break;
+      case StateType::PARAMETER_CARTESIANSTATE:
+        parameter.values.cartesian_state = value.cast<CartesianState>();
+        break;
+      case StateType::PARAMETER_CARTESIANPOSE:
+        parameter.values.cartesian_pose = value.cast<CartesianPose>();
+        break;
+      case StateType::PARAMETER_JOINTSTATE:
+        parameter.values.joint_state = value.cast<JointState>();
+        break;
+      case StateType::PARAMETER_JOINTPOSITIONS:
+        parameter.values.joint_positions = value.cast<JointPositions>();
+        break;
+      case StateType::PARAMETER_MATRIX:
+        parameter.values.matrix_value = value.cast<Eigen::MatrixXd>();
+        break;
+      case StateType::PARAMETER_VECTOR:
+        parameter.values.vector_value = value.cast<Eigen::VectorXd>();
+        break;
+      default:
+        break;
+    }
+  }, "Setter of the value attribute.", py::arg("value"));
+
+  c.def("get_value", [](const ParameterContainer& parameter) -> py::object {
+    switch (parameter.get_type()) {
+      case StateType::PARAMETER_DOUBLE:
+        return py::cast(parameter.values.double_value);
+      case StateType::PARAMETER_DOUBLE_ARRAY:
+        return py::cast(parameter.values.double_array_value);
+      case StateType::PARAMETER_BOOL:
+        return py::cast(parameter.values.bool_value);
+      case StateType::PARAMETER_BOOL_ARRAY:
+        return py::cast(parameter.values.bool_array_value);
+      case StateType::PARAMETER_STRING:
+        return py::cast(parameter.values.string_value);
+      case StateType::PARAMETER_STRING_ARRAY:
+        return py::cast(parameter.values.string_array_value);
+      case StateType::PARAMETER_CARTESIANSTATE:
+        return py::cast(parameter.values.cartesian_state);
+      case StateType::PARAMETER_CARTESIANPOSE:
+        return py::cast(parameter.values.cartesian_pose);
+      case StateType::PARAMETER_JOINTSTATE:
+        return py::cast(parameter.values.joint_state);
+      case StateType::PARAMETER_JOINTPOSITIONS:
+        return py::cast(parameter.values.joint_positions);
+      case StateType::PARAMETER_MATRIX:
+        return py::cast(parameter.values.matrix_value);
+      case StateType::PARAMETER_VECTOR:
+        return py::cast(parameter.values.vector_value);
+      default:
+        return py::none();
+    }
+  }, "Getter of the value attribute.");
+
+  c.def("__repr__", [](const ParameterContainer& parameter) {
+    std::stringstream buffer;
+    switch (parameter.get_type()) {
+      case StateType::PARAMETER_DOUBLE: {
+        Parameter<double> param(parameter.get_name(), parameter.values.double_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_DOUBLE_ARRAY: {
+        Parameter<std::vector<double>> param(parameter.get_name(), parameter.values.double_array_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_BOOL: {
+        Parameter<bool> param(parameter.get_name(), parameter.values.bool_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_BOOL_ARRAY: {
+        Parameter<std::vector<bool>> param(parameter.get_name(), parameter.values.bool_array_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_STRING: {
+        Parameter<std::string> param(parameter.get_name(), parameter.values.string_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_STRING_ARRAY: {
+        Parameter<std::vector<std::string>> param(parameter.get_name(), parameter.values.string_array_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_CARTESIANSTATE: {
+        Parameter<CartesianState> param(parameter.get_name(), parameter.values.cartesian_state);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_CARTESIANPOSE: {
+        Parameter<CartesianPose> param(parameter.get_name(), parameter.values.cartesian_pose);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_JOINTSTATE: {
+        Parameter<JointState> param(parameter.get_name(), parameter.values.joint_state);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_JOINTPOSITIONS: {
+        Parameter<JointPositions> param(parameter.get_name(), parameter.values.joint_positions);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_MATRIX: {
+        Parameter<Eigen::MatrixXd> param(parameter.get_name(), parameter.values.matrix_value);
+        buffer << param;
+        break;
+      }
+      case StateType::PARAMETER_VECTOR: {
+        Parameter<Eigen::VectorXd> param(parameter.get_name(), parameter.values.vector_value);
+        buffer << param;
+        break;
+      }
+      default:
+        break;
+    }
+    return buffer.str();
+  });
+}
+
+void bind_parameters(py::module_& m) {
+  parameter_interface(m);
+  parameter(m);
+}

--- a/python/source/state_representation/state_representation_bindings.cpp
+++ b/python/source/state_representation/state_representation_bindings.cpp
@@ -16,4 +16,5 @@ PYBIND11_MODULE(state_representation, m) {
   bind_cartesian_space(m);
   bind_joint_space(m);
   bind_jacobian(m);
+  bind_parameters(m);
 }

--- a/python/source/state_representation/state_representation_bindings.h
+++ b/python/source/state_representation/state_representation_bindings.h
@@ -23,3 +23,4 @@ void bind_state(py::module_& m);
 void bind_cartesian_space(py::module_& m);
 void bind_joint_space(py::module_& m);
 void bind_jacobian(py::module_& m);
+void bind_parameters(py::module_& m);

--- a/python/test/test_parameters.py
+++ b/python/test/test_parameters.py
@@ -1,0 +1,129 @@
+import unittest
+import state_representation as sr
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+
+class TestParameters(unittest.TestCase):
+
+    def test_param_double(self):
+        param = sr.Parameter("double", sr.StateType.PARAMETER_DOUBLE)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "double")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_DOUBLE)
+        param.set_value(1.5)
+        self.assertEqual(param.get_value(), 1.5)
+
+    def test_param_double_array(self):
+        param = sr.Parameter("double_array", sr.StateType.PARAMETER_DOUBLE_ARRAY)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "double_array")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_DOUBLE_ARRAY)
+        values = [2.2, 3.3, 4.4]
+        param.set_value(values)
+        [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+
+    def test_param_bool(self):
+        param = sr.Parameter("bool", sr.StateType.PARAMETER_BOOL)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "bool")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_BOOL)
+        param.set_value(False)
+        self.assertEqual(param.get_value(), False)
+
+    def test_param_bool_array(self):
+        param = sr.Parameter("bool_array", sr.StateType.PARAMETER_BOOL_ARRAY)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "bool_array")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_BOOL_ARRAY)
+        values = [True, False, False]
+        param.set_value(values)
+        [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+
+    def test_param_string(self):
+        param = sr.Parameter("string", sr.StateType.PARAMETER_STRING)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "string")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_STRING)
+        param.set_value("parameter")
+        self.assertEqual(param.get_value(), "parameter")
+
+    def test_param_string_array(self):
+        param = sr.Parameter("string_array", sr.StateType.PARAMETER_STRING_ARRAY)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "string_array")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_STRING_ARRAY)
+        values = ["test", "parameter", "bindings"]
+        param.set_value(values)
+        [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+
+    def test_param_cartesian_state(self):
+        param = sr.Parameter("cartesian_state", sr.StateType.PARAMETER_CARTESIANSTATE)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "cartesian_state")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_CARTESIANSTATE)
+        values = sr.CartesianState.Random("test")
+        param.set_value(values)
+        param_value = param.get_value()
+        self.assertTrue(param_value.get_name(), values.get_name())
+        self.assertTrue(param_value.get_reference_frame(), values.get_reference_frame())
+        assert_array_equal(param_value.data(), values.data())
+
+    def test_param_cartesian_pose(self):
+        param = sr.Parameter("cartesian_pose", sr.StateType.PARAMETER_CARTESIANPOSE)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "cartesian_pose")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_CARTESIANPOSE)
+        values = sr.CartesianPose.Random("test")
+        param.set_value(values)
+        param_value = param.get_value()
+        self.assertTrue(param_value.get_name(), values.get_name())
+        self.assertTrue(param_value.get_reference_frame(), values.get_reference_frame())
+        assert_array_equal(param_value.data(), values.data())
+
+    def test_param_joint_state(self):
+        param = sr.Parameter("joint_state", sr.StateType.PARAMETER_JOINTSTATE)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "joint_state")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_JOINTSTATE)
+        values = sr.JointState.Random("test", 3)
+        param.set_value(values)
+        param_value = param.get_value()
+        self.assertTrue(param_value.get_name(), values.get_name())
+        self.assertTrue(param_value.get_size(), values.get_size())
+        assert_array_equal(param_value.data(), values.data())
+
+    def test_param_cartesian_pose(self):
+        param = sr.Parameter("joint_positions", sr.StateType.PARAMETER_JOINTPOSITIONS)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "joint_positions")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_JOINTPOSITIONS)
+        values = sr.JointPositions.Random("test", 3)
+        param.set_value(values)
+        param_value = param.get_value()
+        self.assertTrue(param_value.get_name(), values.get_name())
+        self.assertTrue(param_value.get_size(), values.get_size())
+        assert_array_equal(param_value.data(), values.data())
+
+    def test_param_matrix(self):
+        param = sr.Parameter("matrix", sr.StateType.PARAMETER_MATRIX)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "matrix")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_MATRIX)
+        values = np.random.rand(3, 2)
+        param.set_value(values)
+        assert_array_equal(param.get_value(), values)
+
+    def test_param_vector(self):
+        param = sr.Parameter("vector", sr.StateType.PARAMETER_VECTOR)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "vector")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_VECTOR)
+        values = np.random.rand(3)
+        param.set_value(values)
+        assert_array_equal(param.get_value(), values)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/test/test_parameters.py
+++ b/python/test/test_parameters.py
@@ -7,6 +7,16 @@ from numpy.testing import assert_array_equal
 
 class TestParameters(unittest.TestCase):
 
+    def cartesian_equal(self, cartesian1, cartesian2):
+        self.assertTrue(cartesian1.get_name(), cartesian2.get_name())
+        self.assertTrue(cartesian1.get_reference_frame(), cartesian2.get_reference_frame())
+        assert_array_equal(cartesian1.data(), cartesian2.data())
+
+    def joint_equal(self, joint1, joint2):
+        self.assertTrue(joint1.get_name(), joint2.get_name())
+        self.assertTrue(joint1.get_size(), joint2.get_size())
+        assert_array_equal(joint1.data(), joint2.data())
+
     def test_param_int(self):
         param = sr.Parameter("int", sr.StateType.PARAMETER_INT)
         self.assertTrue(param.is_empty())
@@ -14,6 +24,8 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_INT)
         param.set_value(1)
         self.assertEqual(param.get_value(), 1)
+        param1 = sr.Parameter("int", 1, sr.StateType.PARAMETER_INT)
+        self.assertEqual(param1.get_value(), 1)
 
     def test_param_int_array(self):
         param = sr.Parameter("int_array", sr.StateType.PARAMETER_INT_ARRAY)
@@ -23,6 +35,8 @@ class TestParameters(unittest.TestCase):
         values = [2, 3, 4]
         param.set_value(values)
         [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+        param1 = sr.Parameter("int_array", values, sr.StateType.PARAMETER_INT_ARRAY)
+        [self.assertEqual(param1.get_value()[i], values[i]) for i in range(len(values))]
 
     def test_param_double(self):
         param = sr.Parameter("double", sr.StateType.PARAMETER_DOUBLE)
@@ -31,6 +45,8 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_DOUBLE)
         param.set_value(1.5)
         self.assertEqual(param.get_value(), 1.5)
+        param1 = sr.Parameter("double", 1.5, sr.StateType.PARAMETER_DOUBLE)
+        self.assertEqual(param1.get_value(), 1.5)
 
     def test_param_double_array(self):
         param = sr.Parameter("double_array", sr.StateType.PARAMETER_DOUBLE_ARRAY)
@@ -40,6 +56,8 @@ class TestParameters(unittest.TestCase):
         values = [2.2, 3.3, 4.4]
         param.set_value(values)
         [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+        param1 = sr.Parameter("double_array", values, sr.StateType.PARAMETER_DOUBLE_ARRAY)
+        [self.assertEqual(param1.get_value()[i], values[i]) for i in range(len(values))]
 
     def test_param_bool(self):
         param = sr.Parameter("bool", sr.StateType.PARAMETER_BOOL)
@@ -48,6 +66,8 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_BOOL)
         param.set_value(False)
         self.assertEqual(param.get_value(), False)
+        param1 = sr.Parameter("bool", False, sr.StateType.PARAMETER_BOOL)
+        self.assertEqual(param1.get_value(), False)
 
     def test_param_bool_array(self):
         param = sr.Parameter("bool_array", sr.StateType.PARAMETER_BOOL_ARRAY)
@@ -57,6 +77,8 @@ class TestParameters(unittest.TestCase):
         values = [True, False, False]
         param.set_value(values)
         [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+        param1 = sr.Parameter("bool_array", values, sr.StateType.PARAMETER_BOOL_ARRAY)
+        [self.assertEqual(param1.get_value()[i], values[i]) for i in range(len(values))]
 
     def test_param_string(self):
         param = sr.Parameter("string", sr.StateType.PARAMETER_STRING)
@@ -65,6 +87,8 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_STRING)
         param.set_value("parameter")
         self.assertEqual(param.get_value(), "parameter")
+        param1 = sr.Parameter("string", "parameter", sr.StateType.PARAMETER_STRING)
+        self.assertEqual(param1.get_value(), "parameter")
 
     def test_param_string_array(self):
         param = sr.Parameter("string_array", sr.StateType.PARAMETER_STRING_ARRAY)
@@ -74,6 +98,8 @@ class TestParameters(unittest.TestCase):
         values = ["test", "parameter", "bindings"]
         param.set_value(values)
         [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+        param1 = sr.Parameter("string_array", values, sr.StateType.PARAMETER_STRING_ARRAY)
+        [self.assertEqual(param1.get_value()[i], values[i]) for i in range(len(values))]
 
     def test_param_cartesian_state(self):
         param = sr.Parameter("cartesian_state", sr.StateType.PARAMETER_CARTESIANSTATE)
@@ -82,10 +108,9 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_CARTESIANSTATE)
         values = sr.CartesianState.Random("test")
         param.set_value(values)
-        param_value = param.get_value()
-        self.assertTrue(param_value.get_name(), values.get_name())
-        self.assertTrue(param_value.get_reference_frame(), values.get_reference_frame())
-        assert_array_equal(param_value.data(), values.data())
+        self.cartesian_equal(param.get_value(), values)
+        param1 = sr.Parameter("cartesian_state", values, sr.StateType.PARAMETER_CARTESIANSTATE)
+        self.cartesian_equal(param1.get_value(), values)
 
     def test_param_cartesian_pose(self):
         param = sr.Parameter("cartesian_pose", sr.StateType.PARAMETER_CARTESIANPOSE)
@@ -94,10 +119,9 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_CARTESIANPOSE)
         values = sr.CartesianPose.Random("test")
         param.set_value(values)
-        param_value = param.get_value()
-        self.assertTrue(param_value.get_name(), values.get_name())
-        self.assertTrue(param_value.get_reference_frame(), values.get_reference_frame())
-        assert_array_equal(param_value.data(), values.data())
+        self.cartesian_equal(param.get_value(), values)
+        param1 = sr.Parameter("cartesian_pose", values, sr.StateType.PARAMETER_CARTESIANPOSE)
+        self.cartesian_equal(param1.get_value(), values)
 
     def test_param_joint_state(self):
         param = sr.Parameter("joint_state", sr.StateType.PARAMETER_JOINTSTATE)
@@ -106,10 +130,9 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_JOINTSTATE)
         values = sr.JointState.Random("test", 3)
         param.set_value(values)
-        param_value = param.get_value()
-        self.assertTrue(param_value.get_name(), values.get_name())
-        self.assertTrue(param_value.get_size(), values.get_size())
-        assert_array_equal(param_value.data(), values.data())
+        self.joint_equal(param.get_value(), values)
+        param1 = sr.Parameter("joint_state", values, sr.StateType.PARAMETER_JOINTSTATE)
+        self.joint_equal(param1.get_value(), values)
 
     def test_param_cartesian_pose(self):
         param = sr.Parameter("joint_positions", sr.StateType.PARAMETER_JOINTPOSITIONS)
@@ -118,10 +141,9 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(param.get_type(), sr.StateType.PARAMETER_JOINTPOSITIONS)
         values = sr.JointPositions.Random("test", 3)
         param.set_value(values)
-        param_value = param.get_value()
-        self.assertTrue(param_value.get_name(), values.get_name())
-        self.assertTrue(param_value.get_size(), values.get_size())
-        assert_array_equal(param_value.data(), values.data())
+        self.joint_equal(param.get_value(), values)
+        param1 = sr.Parameter("joint_positions", values, sr.StateType.PARAMETER_JOINTPOSITIONS)
+        self.joint_equal(param1.get_value(), values)
 
     def test_param_matrix(self):
         param = sr.Parameter("matrix", sr.StateType.PARAMETER_MATRIX)
@@ -131,6 +153,8 @@ class TestParameters(unittest.TestCase):
         values = np.random.rand(3, 2)
         param.set_value(values)
         assert_array_equal(param.get_value(), values)
+        param1 = sr.Parameter("matrix", values, sr.StateType.PARAMETER_MATRIX)
+        assert_array_equal(param1.get_value(), values)
 
     def test_param_vector(self):
         param = sr.Parameter("vector", sr.StateType.PARAMETER_VECTOR)
@@ -140,6 +164,8 @@ class TestParameters(unittest.TestCase):
         values = np.random.rand(3)
         param.set_value(values)
         assert_array_equal(param.get_value(), values)
+        param1 = sr.Parameter("vector", values, sr.StateType.PARAMETER_VECTOR)
+        assert_array_equal(param1.get_value(), values)
 
 
 if __name__ == '__main__':

--- a/python/test/test_parameters.py
+++ b/python/test/test_parameters.py
@@ -17,6 +17,10 @@ class TestParameters(unittest.TestCase):
         self.assertTrue(joint1.get_size(), joint2.get_size())
         assert_array_equal(joint1.data(), joint2.data())
 
+    def test_param_invalid(self):
+        param = sr.Parameter("test", sr.StateType.CARTESIANSTATE)
+        self.assertRaises(ValueError, param.set_value, 1)
+
     def test_param_int(self):
         param = sr.Parameter("int", sr.StateType.PARAMETER_INT)
         self.assertTrue(param.is_empty())

--- a/python/test/test_parameters.py
+++ b/python/test/test_parameters.py
@@ -7,6 +7,23 @@ from numpy.testing import assert_array_equal
 
 class TestParameters(unittest.TestCase):
 
+    def test_param_int(self):
+        param = sr.Parameter("int", sr.StateType.PARAMETER_INT)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "int")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_INT)
+        param.set_value(1)
+        self.assertEqual(param.get_value(), 1)
+
+    def test_param_int_array(self):
+        param = sr.Parameter("int_array", sr.StateType.PARAMETER_INT_ARRAY)
+        self.assertTrue(param.is_empty())
+        self.assertEqual(param.get_name(), "int_array")
+        self.assertEqual(param.get_type(), sr.StateType.PARAMETER_INT_ARRAY)
+        values = [2, 3, 4]
+        param.set_value(values)
+        [self.assertEqual(param.get_value()[i], values[i]) for i in range(len(values))]
+
     def test_param_double(self):
         param = sr.Parameter("double", sr.StateType.PARAMETER_DOUBLE)
         self.assertTrue(param.is_empty())


### PR DESCRIPTION
I added here the Python binding for the Parameter class. Due to the fact that the class is templated, we had to apply a few tricks. I am therrefore creating a cpp class `ParameterContainer` that is a derived class of `ParameterInterface` and that stores all the different parameter fields in a struct, which is then accessed by switch cases in the python methods. Additionally, you have to provide the `StateType` to the constructor of a `Parameter` in Python, so the class behaves slightly different to the cpp one,