### PR TITLE
Refactor CartesianState tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Release Versions:
 - Add Python bindings for Parameter class (#209)
 - Add Python bindings for clproto encode / decode of Parameter class (#214)
 
+### Pending TODOs for the next release
+
+- Including a quaternion extension (numpy-quaternion, pyquaternion, ...)
+  for binding the Eigen::Quaternion to a specific object in Python.
+
 ## 4.0.0
 
 Version 4.0.0 introduces some powerful new features for using `state_representation` objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Release Versions:
 - Add possibility to have a ssh server for Python testing (#211)
 - Add Python bindings for Parameter class (#209)
 - Add Python bindings for clproto encode / decode of Parameter class (#214)
+- Improve CartesianState tests in C++ and Python (#213)
 
 ### Pending TODOs for the next release
 

--- a/python/dev-server.sh
+++ b/python/dev-server.sh
@@ -45,9 +45,11 @@ in the 'source' directory."
 
 docker image inspect "${BASE_IMAGE}" >/dev/null 2>&1 || image_not_found
 
+BUILD_ARGS=(--build-arg BASE_IMAGE=control-libraries/remote-development:latest)
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -b|--branch) BRANCH=$2; shift 2;;
+    -r|--rebuild) BUILD_ARGS+=(--no-cache); shift 1;;
     -p|--port) SSH_PORT=$2; shift 2;;
     -k|--key-file) SSH_KEY_FILE=$2; shift 2;;
     -h|--help) echo "${HELP_MESSAGE}"; exit 0;;
@@ -56,10 +58,10 @@ while [ "$#" -gt 0 ]; do
 done
 
 echo "Using control libraries branch ${BRANCH}"
+BUILD_ARGS+=(--build-arg BRANCH="${BRANCH}")
 
 DOCKER_BUILDKIT=1 docker build . --file ./Dockerfile.python \
-  --build-arg BASE_IMAGE=control-libraries/remote-development:latest \
-  --build-arg BRANCH="${BRANCH}" \
+  "${BUILD_ARGS[@]}" \
   --target remote-user \
   --tag "${IMAGE_NAME}" || exit 1
 

--- a/python/run.sh
+++ b/python/run.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
 
 BRANCH=$(git branch --show-current)
-if [ -n "$1" ]; then
-  BRANCH=$1
-fi
+
+BUILD_ARGS=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -b|--branch) BRANCH=$2; shift 2;;
+    -r|--rebuild) BUILD_ARGS+=(--no-cache); shift 1;;
+    *) echo "Unknown option: $1" >&2; exit 1;;
+  esac
+done
+
 echo "Using control libraries branch ${BRANCH}"
+BUILD_ARGS+=(--build-arg BRANCH="${BRANCH}")
 
 docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest
 docker build . --file ./Dockerfile.python \
-  --build-arg BRANCH="${BRANCH}" \
+  "${BUILD_ARGS[@]}" \
   --target dev-user \
   --tag control-libraries/python/test || exit 1
 

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -105,6 +105,8 @@ void cartesian_state(py::module_& m) {
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(double() * py::self);
+  c.def(py::self /= double());
+  c.def(py::self / double());
   c.def(py::self += py::self);
   c.def(py::self + py::self);
   c.def(py::self -= py::self);
@@ -174,6 +176,8 @@ void cartesian_pose(py::module_& m) {
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(double() * py::self);
+  c.def(py::self /= double());
+  c.def(py::self / double());
 
   c.def(py::self += py::self);
   c.def(py::self + py::self);
@@ -237,6 +241,8 @@ void cartesian_twist(py::module_& m) {
 
   c.def(py::self *= double());
   c.def(py::self * double());
+  c.def(py::self /= double());
+  c.def(py::self / double());
   c.def(py::self *= Eigen::Matrix<double, 6, 6>());
   c.def(py::self * std::chrono::nanoseconds());
 
@@ -302,6 +308,8 @@ void cartesian_wrench(py::module_& m) {
   c.def(py::self *= double());
   c.def(py::self * double());
   c.def(double() * py::self);
+  c.def(py::self /= double());
+  c.def(py::self / double());
 
   c.def("clamp", &CartesianWrench::clamp, "Clamp inplace the magnitude of the wrench to the values in argument", "max_force"_a, "max_torque"_a, "force_noise_ratio"_a=0, "torque_noise_ratio"_a=0);
   c.def("clamped", &CartesianWrench::clamped, "Return the clamped wrench", "max_force"_a, "max_torque"_a, "force_noise_ratio"_a=0, "torque_noise_ratio"_a=0);

--- a/python/test/space/test_cartesian_state.py
+++ b/python/test/space/test_cartesian_state.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 from state_representation import CartesianState, StateType, CartesianStateVariable
 
 from .test_spatial_state import SPATIAL_STATE_METHOD_EXPECTS
@@ -63,12 +64,6 @@ CARTESIAN_STATE_METHOD_EXPECTS = [
 
 
 class TestCartesianState(unittest.TestCase):
-    def assert_np_array_equal(self, a, b):
-        self.assertListEqual(list(a), list(b))
-
-    def assert_np_array_almost_equal(self, a, b):
-        [self.assertAlmostEqual(x, y) for x, y in zip(list(a), list(b))]
-
     def assert_name_empty_frame_equal(self, state, name, empty, reference_frame):
         self.assertEqual(state.get_name(), name)
         self.assertEqual(state.is_empty(), empty)
@@ -77,7 +72,7 @@ class TestCartesianState(unittest.TestCase):
     def assert_name_frame_data_equal(self, state1, state2):
         self.assertEqual(state1.get_name(), state2.get_name())
         self.assertEqual(state1.get_reference_frame(), state2.get_reference_frame())
-        self.assert_np_array_almost_equal(state1.data(), state2.data())
+        assert_array_almost_equal(state1.data(), state2.data())
 
     def clamping_helper(self, state, getter, setter, variable, dim):
         if dim == 3:
@@ -175,7 +170,7 @@ class TestCartesianState(unittest.TestCase):
         cs.set_position(position)
         [self.assertAlmostEqual(cs.get_position()[i], position[i]) for i in range(3)]
         cs.set_position(1.1, 2.2, 3.3)
-        self.assert_np_array_equal(np.array([1.1, 2.2, 3.3]), cs.get_position())
+        assert_array_equal(np.array([1.1, 2.2, 3.3]), cs.get_position())
 
         # orientation
         orientation_vec = np.random.rand(4)
@@ -190,51 +185,51 @@ class TestCartesianState(unittest.TestCase):
         trans = matrix[:3, 3]
         # rot = matrix[:3, :3]
         bottom = matrix[3, :]
-        self.assert_np_array_almost_equal(trans, cs.get_position())
+        assert_array_almost_equal(trans, cs.get_position())
         # TODO rotation matrix from quaternion
-        self.assert_np_array_almost_equal(bottom, np.array([0, 0, 0, 1]))
+        assert_array_equal(bottom, np.array([0, 0, 0, 1]))
 
         # pose
         position = [4.4, 5.5, 6.6]
         orientation_vec = np.random.rand(4)
         orientation_vec = orientation_vec / np.linalg.norm(orientation_vec)
         cs.set_pose(np.hstack((position, orientation_vec)))
-        self.assert_np_array_almost_equal(np.hstack((position, orientation_vec)), cs.get_pose())
+        assert_array_almost_equal(np.hstack((position, orientation_vec)), cs.get_pose())
         with self.assertRaises(RuntimeError):
             cs.set_pose(position)
 
         # twist
         linear_velocity = np.random.rand(3)
         cs.set_linear_velocity(linear_velocity)
-        self.assert_np_array_almost_equal(cs.get_linear_velocity(), linear_velocity)
+        assert_array_almost_equal(cs.get_linear_velocity(), linear_velocity)
         angular_velocity = np.random.rand(3)
         cs.set_angular_velocity(angular_velocity)
-        self.assert_np_array_almost_equal(cs.get_angular_velocity(), angular_velocity)
+        assert_array_almost_equal(cs.get_angular_velocity(), angular_velocity)
         twist = np.random.rand(6)
         cs.set_twist(twist)
-        self.assert_np_array_almost_equal(cs.get_twist(), twist)
+        assert_array_almost_equal(cs.get_twist(), twist)
 
         # acceleration
         linear_acceleration = np.random.rand(3)
         cs.set_linear_acceleration(linear_acceleration)
-        self.assert_np_array_almost_equal(cs.get_linear_acceleration(), linear_acceleration)
+        assert_array_almost_equal(cs.get_linear_acceleration(), linear_acceleration)
         angular_acceleration = np.random.rand(3)
         cs.set_angular_acceleration(angular_acceleration)
-        self.assert_np_array_almost_equal(cs.get_angular_acceleration(), angular_acceleration)
+        assert_array_almost_equal(cs.get_angular_acceleration(), angular_acceleration)
         accelerations = np.random.rand(6)
         cs.set_accelerations(accelerations)
-        self.assert_np_array_almost_equal(cs.get_accelerations(), accelerations)
+        assert_array_almost_equal(cs.get_accelerations(), accelerations)
 
         # wrench
         force = np.random.rand(3)
         cs.set_force(force)
-        self.assert_np_array_almost_equal(cs.get_force(), force)
+        assert_array_almost_equal(cs.get_force(), force)
         torque = np.random.rand(3)
         cs.set_torque(torque)
-        self.assert_np_array_almost_equal(cs.get_torque(), torque)
+        assert_array_almost_equal(cs.get_torque(), torque)
         wrench = np.random.rand(6)
         cs.set_wrench(wrench)
-        self.assert_np_array_almost_equal(cs.get_wrench(), wrench)
+        assert_array_almost_equal(cs.get_wrench(), wrench)
 
         cs.set_zero()
         self.assertAlmostEqual(np.linalg.norm(cs.data()), 1)
@@ -265,11 +260,11 @@ class TestCartesianState(unittest.TestCase):
         cs1 = CartesianState().Identity("test")
         cs2 = CartesianState().Random("test")
         concatenated_state = np.hstack((cs1.get_pose(), cs1.get_twist(), cs1.get_accelerations(), cs1.get_wrench()))
-        self.assert_np_array_almost_equal(cs1.data(), concatenated_state)
-        self.assert_np_array_almost_equal(cs1.array(), concatenated_state)
+        assert_array_almost_equal(cs1.data(), concatenated_state)
+        assert_array_almost_equal(cs1.array(), concatenated_state)
 
         cs1.set_data(cs2.data())
-        self.assert_np_array_almost_equal(cs1.data(), cs2.data())
+        assert_array_almost_equal(cs1.data(), cs2.data())
 
         cs2 = CartesianState.Random("test")
         state_vec = cs2.to_list()
@@ -374,15 +369,15 @@ class TestCartesianState(unittest.TestCase):
 
         csum = cs1 + cs2
         self.assertEqual(type(csum), CartesianState)
-        self.assert_np_array_almost_equal(csum.get_position(), cs1.get_position() + cs2.get_position())
+        assert_array_almost_equal(csum.get_position(), cs1.get_position() + cs2.get_position())
         # TODO orientation sum
-        self.assert_np_array_almost_equal(csum.get_twist(), cs1.get_twist() + cs2.get_twist())
-        self.assert_np_array_almost_equal(csum.get_accelerations(), cs1.get_accelerations() + cs2.get_accelerations())
-        self.assert_np_array_almost_equal(csum.get_wrench(), cs1.get_wrench() + cs2.get_wrench())
+        assert_array_almost_equal(csum.get_twist(), cs1.get_twist() + cs2.get_twist())
+        assert_array_almost_equal(csum.get_accelerations(), cs1.get_accelerations() + cs2.get_accelerations())
+        assert_array_almost_equal(csum.get_wrench(), cs1.get_wrench() + cs2.get_wrench())
 
         cs1 += cs2
         self.assertEqual(type(cs1), CartesianState)
-        self.assert_np_array_almost_equal(cs1.data(), csum.data())
+        assert_array_almost_equal(cs1.data(), csum.data())
 
     def test_subtraction(self):
         cs1 = CartesianState().Random("test")
@@ -394,30 +389,30 @@ class TestCartesianState(unittest.TestCase):
 
         cdiff = cs1 - cs2
         self.assertEqual(type(cdiff), CartesianState)
-        self.assert_np_array_almost_equal(cdiff.get_position(), cs1.get_position() - cs2.get_position())
+        assert_array_almost_equal(cdiff.get_position(), cs1.get_position() - cs2.get_position())
         # TODO orientation diff
-        self.assert_np_array_almost_equal(cdiff.get_twist(), cs1.get_twist() - cs2.get_twist())
-        self.assert_np_array_almost_equal(cdiff.get_accelerations(), cs1.get_accelerations() - cs2.get_accelerations())
-        self.assert_np_array_almost_equal(cdiff.get_wrench(), cs1.get_wrench() - cs2.get_wrench())
+        assert_array_almost_equal(cdiff.get_twist(), cs1.get_twist() - cs2.get_twist())
+        assert_array_almost_equal(cdiff.get_accelerations(), cs1.get_accelerations() - cs2.get_accelerations())
+        assert_array_almost_equal(cdiff.get_wrench(), cs1.get_wrench() - cs2.get_wrench())
 
         cs1 -= cs2
         self.assertEqual(type(cs1), CartesianState)
-        self.assert_np_array_almost_equal(cs1.data(), cdiff.data())
+        assert_array_almost_equal(cs1.data(), cdiff.data())
 
     def test_scalar_multiplication(self):
         scalar = 2.0
         cs = CartesianState().Random("test")
         cscaled = scalar * cs
         self.assertEqual(type(cscaled), CartesianState)
-        self.assert_np_array_almost_equal(cscaled.get_position(), scalar * cs.get_position())
+        assert_array_almost_equal(cscaled.get_position(), scalar * cs.get_position())
         # TODO orientation mult
-        self.assert_np_array_almost_equal(cscaled.get_twist(), scalar * cs.get_twist())
-        self.assert_np_array_almost_equal(cscaled.get_accelerations(), scalar * cs.get_accelerations())
-        self.assert_np_array_almost_equal(cscaled.get_wrench(), scalar * cs.get_wrench())
+        assert_array_almost_equal(cscaled.get_twist(), scalar * cs.get_twist())
+        assert_array_almost_equal(cscaled.get_accelerations(), scalar * cs.get_accelerations())
+        assert_array_almost_equal(cscaled.get_wrench(), scalar * cs.get_wrench())
 
         cs *= scalar
         self.assertEqual(type(cs), CartesianState)
-        self.assert_np_array_almost_equal(cs.data(), cscaled.data())
+        assert_array_almost_equal(cs.data(), cscaled.data())
 
         empty = CartesianState()
         with self.assertRaises(RuntimeError):
@@ -428,15 +423,15 @@ class TestCartesianState(unittest.TestCase):
         cs = CartesianState().Random("test")
         cscaled = cs / scalar
         self.assertEqual(type(cscaled), CartesianState)
-        self.assert_np_array_almost_equal(cscaled.get_position(), cs.get_position() / scalar)
+        assert_array_almost_equal(cscaled.get_position(), cs.get_position() / scalar)
         # TODO orientation diff
-        self.assert_np_array_almost_equal(cscaled.get_twist(), cs.get_twist() / scalar)
-        self.assert_np_array_almost_equal(cscaled.get_accelerations(), cs.get_accelerations() / scalar)
-        self.assert_np_array_almost_equal(cscaled.get_wrench(), cs.get_wrench() / scalar)
+        assert_array_almost_equal(cscaled.get_twist(), cs.get_twist() / scalar)
+        assert_array_almost_equal(cscaled.get_accelerations(), cs.get_accelerations() / scalar)
+        assert_array_almost_equal(cscaled.get_wrench(), cs.get_wrench() / scalar)
 
         cs /= scalar
         self.assertEqual(type(cs), CartesianState)
-        self.assert_np_array_almost_equal(cs.data(), cscaled.data())
+        assert_array_almost_equal(cs.data(), cscaled.data())
 
         with self.assertRaises(RuntimeError):
             cs / 0.0

--- a/python/test/space/test_cartesian_state.py
+++ b/python/test/space/test_cartesian_state.py
@@ -1,6 +1,10 @@
 import unittest
-from state_representation import CartesianState, dist
+
 import numpy as np
+from state_representation import CartesianState, StateType, CartesianStateVariable
+
+from .test_spatial_state import SPATIAL_STATE_METHOD_EXPECTS
+from ..test_state import STATE_METHOD_EXPECTS
 
 CARTESIAN_STATE_METHOD_EXPECTS = [
     'Identity',
@@ -57,66 +61,390 @@ CARTESIAN_STATE_METHOD_EXPECTS = [
     'to_list'
 ]
 
+
 class TestCartesianState(unittest.TestCase):
     def assert_np_array_equal(self, a, b):
         self.assertListEqual(list(a), list(b))
 
     def assert_np_array_almost_equal(self, a, b):
-        [self.assertAlmostEqual(x, y) for x, y in zip(list(a),list(b))]
+        [self.assertAlmostEqual(x, y) for x, y in zip(list(a), list(b))]
+
+    def assert_name_empty_frame_equal(self, state, name, empty, reference_frame):
+        self.assertEqual(state.get_name(), name)
+        self.assertEqual(state.is_empty(), empty)
+        self.assertEqual(state.get_reference_frame(), reference_frame)
+
+    def assert_name_frame_data_equal(self, state1, state2):
+        self.assertEqual(state1.get_name(), state2.get_name())
+        self.assertEqual(state1.get_reference_frame(), state2.get_reference_frame())
+        self.assert_np_array_almost_equal(state1.data(), state2.data())
+
+    def clamping_helper(self, state, getter, setter, variable, dim):
+        if dim == 3:
+            data = [-2.0, 1.0, 5.0]
+        elif dim == 6:
+            data = [-2.0, 1.0, 5.0, 1.0, -3.0, 2.4]
+        else:
+            raise ValueError("Provide 3 or 6 as dimension")
+
+        setter(data)
+        state.clamp_state_variable(10.0, variable)
+        self.assertEqual(type(state), CartesianState)
+        [self.assertAlmostEqual(getter()[i], data[i]) for i in range(dim)]
+        state.clamp_state_variable(3.0, variable)
+        self.assertAlmostEqual(np.linalg.norm(getter()), 3.0)
+        state.clamp_state_variable(10.0, variable, 0.5)
+        self.assertAlmostEqual(np.linalg.norm(getter()), 0.0)
 
     def test_callable_methods(self):
         methods = [m for m in dir(CartesianState) if callable(getattr(CartesianState, m))]
+        for expected in STATE_METHOD_EXPECTS:
+            self.assertIn(expected, methods)
+        for expected in SPATIAL_STATE_METHOD_EXPECTS:
+            self.assertIn(expected, methods)
+        for expected in CARTESIAN_STATE_METHOD_EXPECTS:
+            self.assertIn(expected, methods)
         for expected in CARTESIAN_STATE_METHOD_EXPECTS:
             self.assertIn(expected, methods)
 
     def test_constructors(self):
-        CartesianState()
-        A = CartesianState("A")
-        CartesianState(A)
-        CartesianState("B", "C")
-        A = CartesianState.Identity("A")
-        B = CartesianState.Random("B")
+        empty1 = CartesianState()
+        self.assertEqual(type(empty1), CartesianState)
+        self.assertEqual(empty1.get_type(), StateType.CARTESIANSTATE)
+        self.assert_name_empty_frame_equal(empty1, "", True, "world")
+        self.assertAlmostEqual(np.linalg.norm(empty1.data()), 1)
 
-    def test_setters(self):
-        A = CartesianState.Identity("A")
+        empty2 = CartesianState("test")
+        self.assertEqual(type(empty1), CartesianState)
+        self.assertEqual(empty2.get_type(), StateType.CARTESIANSTATE)
+        self.assert_name_empty_frame_equal(empty2, "test", True, "world")
+        self.assertAlmostEqual(np.linalg.norm(empty2.data()), 1)
 
-        A.set_position(1, 2, 3)
-        self.assert_np_array_equal(A.get_position(), [1, 2, 3])
-        A.set_position([1, 2, 3])
-        self.assert_np_array_equal(A.get_position(), [1, 2, 3])
-        A.set_position(np.array([1, 2, 3]))
-        self.assert_np_array_equal(A.get_position(), [1, 2, 3])
+        empty3 = CartesianState("test", "reference")
+        self.assertEqual(type(empty1), CartesianState)
+        self.assertEqual(empty3.get_type(), StateType.CARTESIANSTATE)
+        self.assert_name_empty_frame_equal(empty3, "test", True, "reference")
+        self.assertAlmostEqual(np.linalg.norm(empty3.data()), 1)
 
-        A.set_orientation([1, 2, 3, 4])
-        self.assert_np_array_equal(A.get_orientation(), [1, 2, 3, 4] / np.linalg.norm([1, 2, 3, 4]))
+    def test_identity_initialization(self):
+        identity = CartesianState().Identity("test")
+        self.assertFalse(identity.is_empty())
+        self.assertAlmostEqual(np.linalg.norm(identity.get_position()), 0)
+        self.assertAlmostEqual(np.linalg.norm(identity.get_orientation()), 1)
+        self.assertAlmostEqual(identity.get_orientation()[0], 1)
+        self.assertAlmostEqual(np.linalg.norm(identity.get_twist()), 0)
+        self.assertAlmostEqual(np.linalg.norm(identity.get_accelerations()), 0)
+        self.assertAlmostEqual(np.linalg.norm(identity.get_wrench()), 0)
 
-        A.set_twist([1, 2, 3, 4, 5, 6])
-        self.assert_np_array_equal(A.get_twist(), [1, 2, 3, 4, 5, 6])
-        A.set_accelerations([1, 2, 3, 4, 5, 6])
-        self.assert_np_array_equal(A.get_accelerations(), [1, 2, 3, 4, 5, 6])
-        A.set_wrench([1, 2, 3, 4, 5, 6])
-        self.assert_np_array_equal(A.get_wrench(), [1, 2, 3, 4, 5, 6])
+    def test_random_initialization(self):
+        random = CartesianState().Random("test")
+        self.assertFalse(random.is_empty())
+        self.assertTrue(np.linalg.norm(random.get_position()) > 0)
+        self.assertAlmostEqual(np.linalg.norm(random.get_orientation()), 1)
+        [self.assertTrue(random.get_orientation()[i] != 0) for i in range(4)]
+        self.assertTrue(np.linalg.norm(random.get_twist()) > 0)
+        self.assertTrue(np.linalg.norm(random.get_accelerations()) > 0)
+        self.assertTrue(np.linalg.norm(random.get_wrench()) > 0)
 
-        data = [i for i in range(25)]
-        data[3:7] = A.get_orientation().tolist()
-        A.set_data(data)
-        self.assert_np_array_almost_equal(A.data(), data)
+    def test_copy_constructor(self):
+        random = CartesianState().Random("test")
+        copy1 = random
+        self.assert_name_frame_data_equal(random, copy1)
 
-    def test_operators(self):
-        A = CartesianState.Random("A")
-        B = CartesianState.Random("B")
-        CinA = CartesianState.Random("C", "A")
+        copy2 = random.copy()
+        self.assert_name_frame_data_equal(random, copy2)
 
-        C = A * CinA
-        A = A * 2
-        A = 2 * A
-        A *= 2
+        empty = CartesianState()
+        copy2 = empty
+        self.assertTrue(copy2.is_empty())
+        copy3 = empty.copy()
+        self.assertTrue(copy3.is_empty())
 
-        A = A + B
-        A += B
+    def test_get_set_fields(self):
+        cs = CartesianState("test")
 
-        A = A - B
-        A -= B
+        # name
+        cs.set_name("robot")
+        self.assertEqual(cs.get_name(), "robot")
+        self.assertEqual(cs.get_reference_frame(), "world")
+        cs.set_reference_frame("base")
+        self.assertEqual(cs.get_reference_frame(), "base")
+
+        # position
+        position = [1., 2., 3.]
+        cs.set_position(position)
+        [self.assertAlmostEqual(cs.get_position()[i], position[i]) for i in range(3)]
+        cs.set_position(1.1, 2.2, 3.3)
+        self.assert_np_array_equal(np.array([1.1, 2.2, 3.3]), cs.get_position())
+
+        # orientation
+        orientation_vec = np.random.rand(4)
+        orientation_vec = orientation_vec / np.linalg.norm(orientation_vec)
+        cs.set_orientation(orientation_vec)
+        [self.assertAlmostEqual(cs.get_orientation()[i], orientation_vec[i]) for i in range(4)]
+        # TODO what is an Eigen::Quaternion in Python ?
+        with self.assertRaises(RuntimeError):
+            cs.set_orientation(position)
+
+        matrix = cs.get_transformation_matrix()
+        trans = matrix[:3, 3]
+        # rot = matrix[:3, :3]
+        bottom = matrix[3, :]
+        self.assert_np_array_almost_equal(trans, cs.get_position())
+        # TODO rotation matrix from quaternion
+        self.assert_np_array_almost_equal(bottom, np.array([0, 0, 0, 1]))
+
+        # pose
+        position = [4.4, 5.5, 6.6]
+        orientation_vec = np.random.rand(4)
+        orientation_vec = orientation_vec / np.linalg.norm(orientation_vec)
+        cs.set_pose(np.hstack((position, orientation_vec)))
+        self.assert_np_array_almost_equal(np.hstack((position, orientation_vec)), cs.get_pose())
+        with self.assertRaises(RuntimeError):
+            cs.set_pose(position)
+
+        # twist
+        linear_velocity = np.random.rand(3)
+        cs.set_linear_velocity(linear_velocity)
+        self.assert_np_array_almost_equal(cs.get_linear_velocity(), linear_velocity)
+        angular_velocity = np.random.rand(3)
+        cs.set_angular_velocity(angular_velocity)
+        self.assert_np_array_almost_equal(cs.get_angular_velocity(), angular_velocity)
+        twist = np.random.rand(6)
+        cs.set_twist(twist)
+        self.assert_np_array_almost_equal(cs.get_twist(), twist)
+
+        # acceleration
+        linear_acceleration = np.random.rand(3)
+        cs.set_linear_acceleration(linear_acceleration)
+        self.assert_np_array_almost_equal(cs.get_linear_acceleration(), linear_acceleration)
+        angular_acceleration = np.random.rand(3)
+        cs.set_angular_acceleration(angular_acceleration)
+        self.assert_np_array_almost_equal(cs.get_angular_acceleration(), angular_acceleration)
+        accelerations = np.random.rand(6)
+        cs.set_accelerations(accelerations)
+        self.assert_np_array_almost_equal(cs.get_accelerations(), accelerations)
+
+        # wrench
+        force = np.random.rand(3)
+        cs.set_force(force)
+        self.assert_np_array_almost_equal(cs.get_force(), force)
+        torque = np.random.rand(3)
+        cs.set_torque(torque)
+        self.assert_np_array_almost_equal(cs.get_torque(), torque)
+        wrench = np.random.rand(6)
+        cs.set_wrench(wrench)
+        self.assert_np_array_almost_equal(cs.get_wrench(), wrench)
+
+        cs.set_zero()
+        self.assertAlmostEqual(np.linalg.norm(cs.data()), 1)
+        self.assertFalse(cs.is_empty())
+        cs.set_empty()
+        self.assertTrue(cs.is_empty())
+
+    def test_compatibility(self):
+        cs1 = CartesianState("test")
+        cs2 = CartesianState("robot")
+        cs3 = CartesianState("robot", "test")
+        cs4 = CartesianState("test", "robot")
+
+        self.assertFalse(cs1.is_compatible(cs2))
+        self.assertFalse(cs1.is_compatible(cs3))
+        self.assertFalse(cs1.is_compatible(cs4))
+
+    def test_set_zero(self):
+        random1 = CartesianState().Random("test")
+        random1.initialize()
+        self.assertAlmostEqual(np.linalg.norm(random1.data()), 1)
+
+        random2 = CartesianState().Random("test")
+        random2.set_zero()
+        self.assertAlmostEqual(np.linalg.norm(random1.data()), 1)
+
+    def test_get_set_data(self):
+        cs1 = CartesianState().Identity("test")
+        cs2 = CartesianState().Random("test")
+        concatenated_state = np.hstack((cs1.get_pose(), cs1.get_twist(), cs1.get_accelerations(), cs1.get_wrench()))
+        self.assert_np_array_almost_equal(cs1.data(), concatenated_state)
+        self.assert_np_array_almost_equal(cs1.array(), concatenated_state)
+
+        cs1.set_data(cs2.data())
+        self.assert_np_array_almost_equal(cs1.data(), cs2.data())
+
+        cs2 = CartesianState.Random("test")
+        state_vec = cs2.to_list()
+        cs1.set_data(state_vec)
+        [self.assertAlmostEqual(cs1.data()[i], state_vec[i]) for i in range(len(state_vec))]
+
+        with self.assertRaises(RuntimeError):
+            cs1.set_data(np.array([0, 0]))
+
+    def test_clamping(self):
+        state = CartesianState().Identity("test")
+        with self.assertRaises(RuntimeError):
+            state.clamp_state_variable(1, CartesianStateVariable.ORIENTATION)
+        with self.assertRaises(RuntimeError):
+            state.clamp_state_variable(1, CartesianStateVariable.POSE)
+        with self.assertRaises(RuntimeError):
+            state.clamp_state_variable(1, CartesianStateVariable.ALL)
+
+        self.clamping_helper(state, state.get_position, state.set_position, CartesianStateVariable.POSITION, 3)
+        self.clamping_helper(state, state.get_linear_velocity, state.set_linear_velocity,
+                             CartesianStateVariable.LINEAR_VELOCITY, 3)
+        self.clamping_helper(state, state.get_angular_velocity, state.set_angular_velocity,
+                             CartesianStateVariable.ANGULAR_VELOCITY, 3)
+        self.clamping_helper(state, state.get_twist, state.set_twist, CartesianStateVariable.TWIST, 6)
+        self.clamping_helper(state, state.get_linear_acceleration, state.set_linear_acceleration,
+                             CartesianStateVariable.LINEAR_ACCELERATION, 3)
+        self.clamping_helper(state, state.get_angular_acceleration, state.set_angular_acceleration,
+                             CartesianStateVariable.ANGULAR_ACCELERATION, 3)
+        self.clamping_helper(state, state.get_accelerations, state.set_accelerations,
+                             CartesianStateVariable.ACCELERATIONS, 6)
+        self.clamping_helper(state, state.get_force, state.set_force, CartesianStateVariable.FORCE, 3)
+        self.clamping_helper(state, state.get_torque, state.set_torque, CartesianStateVariable.TORQUE, 3)
+        self.clamping_helper(state, state.get_wrench, state.set_wrench, CartesianStateVariable.WRENCH, 6)
+
+    def test_norms(self):
+        cs = CartesianState().Random("test")
+        norms = cs.norms()
+        self.assertEqual(len(norms), 8)
+        self.assertAlmostEqual(norms[0], np.linalg.norm(cs.get_position()))
+        self.assertAlmostEqual(norms[1], np.linalg.norm(cs.get_orientation()))
+        self.assertAlmostEqual(norms[2], np.linalg.norm(cs.get_linear_velocity()))
+        self.assertAlmostEqual(norms[3], np.linalg.norm(cs.get_angular_velocity()))
+        self.assertAlmostEqual(norms[4], np.linalg.norm(cs.get_linear_acceleration()))
+        self.assertAlmostEqual(norms[5], np.linalg.norm(cs.get_angular_acceleration()))
+        self.assertAlmostEqual(norms[6], np.linalg.norm(cs.get_force()))
+        self.assertAlmostEqual(norms[7], np.linalg.norm(cs.get_torque()))
+
+    def test_normalize(self):
+        cs = CartesianState().Random("test")
+        normalized = cs.normalized()
+        self.assertEqual(type(normalized), CartesianState)
+        norms1 = normalized.norms()
+        [self.assertAlmostEqual(n, 1) for n in norms1]
+
+        cs.normalize()
+        norms2 = cs.norms()
+        [self.assertAlmostEqual(n, 1) for n in norms2]
+
+    def test_distance(self):
+        empty = CartesianState()
+        cs1 = CartesianState().Random("test")
+        cs2 = CartesianState().Random("test", "robot")
+
+        with self.assertRaises(RuntimeError):
+            empty.dist(cs1)
+        with self.assertRaises(RuntimeError):
+            cs1.dist(empty)
+        with self.assertRaises(RuntimeError):
+            cs1.dist(cs2)
+
+        data1 = np.random.rand(25)
+        cs1.set_data(data1)
+        cs3 = CartesianState("test")
+        data3 = np.random.rand(25)
+        cs3.set_data(data3)
+
+        pos_dist = np.linalg.norm(data1[:3] - data3[:3])
+        # TODO orientation distance
+        orient_dist = cs1.dist(cs3, CartesianStateVariable.ORIENTATION)
+        lin_vel_dist = np.linalg.norm(data1[7:10] - data3[7:10])
+        ang_vel_dist = np.linalg.norm(data1[10:13] - data3[10:13])
+        lin_acc_dist = np.linalg.norm(data1[13:16] - data3[13:16])
+        ang_acc_dist = np.linalg.norm(data1[16:19] - data3[16:19])
+        force_dist = np.linalg.norm(data1[19:22] - data3[19:22])
+        torque_dist = np.linalg.norm(data1[22:] - data3[22:])
+
+        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.POSITION), pos_dist)
+        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.ORIENTATION), orient_dist)
+        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.POSE), pos_dist + orient_dist)
+        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.TWIST), lin_vel_dist + ang_vel_dist)
+        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.ACCELERATIONS), lin_acc_dist + ang_acc_dist)
+        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.WRENCH), force_dist + torque_dist)
+        self.assertAlmostEqual(cs1.dist(cs3), cs3.dist(cs1, CartesianStateVariable.ALL))
+
+    def test_addition(self):
+        cs1 = CartesianState().Random("test")
+        cs2 = CartesianState().Random("test")
+        cs3 = CartesianState().Random("test", "reference")
+
+        with self.assertRaises(RuntimeError):
+            cs1 + cs3
+
+        csum = cs1 + cs2
+        self.assertEqual(type(csum), CartesianState)
+        self.assert_np_array_almost_equal(csum.get_position(), cs1.get_position() + cs2.get_position())
+        # TODO orientation sum
+        self.assert_np_array_almost_equal(csum.get_twist(), cs1.get_twist() + cs2.get_twist())
+        self.assert_np_array_almost_equal(csum.get_accelerations(), cs1.get_accelerations() + cs2.get_accelerations())
+        self.assert_np_array_almost_equal(csum.get_wrench(), cs1.get_wrench() + cs2.get_wrench())
+
+        cs1 += cs2
+        self.assertEqual(type(cs1), CartesianState)
+        self.assert_np_array_almost_equal(cs1.data(), csum.data())
+
+    def test_subtraction(self):
+        cs1 = CartesianState().Random("test")
+        cs2 = CartesianState().Random("test")
+        cs3 = CartesianState().Random("test", "reference")
+
+        with self.assertRaises(RuntimeError):
+            cs1 - cs3
+
+        cdiff = cs1 - cs2
+        self.assertEqual(type(cdiff), CartesianState)
+        self.assert_np_array_almost_equal(cdiff.get_position(), cs1.get_position() - cs2.get_position())
+        # TODO orientation diff
+        self.assert_np_array_almost_equal(cdiff.get_twist(), cs1.get_twist() - cs2.get_twist())
+        self.assert_np_array_almost_equal(cdiff.get_accelerations(), cs1.get_accelerations() - cs2.get_accelerations())
+        self.assert_np_array_almost_equal(cdiff.get_wrench(), cs1.get_wrench() - cs2.get_wrench())
+
+        cs1 -= cs2
+        self.assertEqual(type(cs1), CartesianState)
+        self.assert_np_array_almost_equal(cs1.data(), cdiff.data())
+
+    def test_scalar_multiplication(self):
+        scalar = 2.0
+        cs = CartesianState().Random("test")
+        cscaled = scalar * cs
+        self.assertEqual(type(cscaled), CartesianState)
+        self.assert_np_array_almost_equal(cscaled.get_position(), scalar * cs.get_position())
+        # TODO orientation mult
+        self.assert_np_array_almost_equal(cscaled.get_twist(), scalar * cs.get_twist())
+        self.assert_np_array_almost_equal(cscaled.get_accelerations(), scalar * cs.get_accelerations())
+        self.assert_np_array_almost_equal(cscaled.get_wrench(), scalar * cs.get_wrench())
+
+        cs *= scalar
+        self.assertEqual(type(cs), CartesianState)
+        self.assert_np_array_almost_equal(cs.data(), cscaled.data())
+
+        empty = CartesianState()
+        with self.assertRaises(RuntimeError):
+            scalar * empty
+
+    def test_scalar_division(self):
+        scalar = 2.0
+        cs = CartesianState().Random("test")
+        cscaled = cs / scalar
+        self.assertEqual(type(cscaled), CartesianState)
+        self.assert_np_array_almost_equal(cscaled.get_position(), cs.get_position() / scalar)
+        # TODO orientation diff
+        self.assert_np_array_almost_equal(cscaled.get_twist(), cs.get_twist() / scalar)
+        self.assert_np_array_almost_equal(cscaled.get_accelerations(), cs.get_accelerations() / scalar)
+        self.assert_np_array_almost_equal(cscaled.get_wrench(), cs.get_wrench() / scalar)
+
+        cs /= scalar
+        self.assertEqual(type(cs), CartesianState)
+        self.assert_np_array_almost_equal(cs.data(), cscaled.data())
+
+        with self.assertRaises(RuntimeError):
+            cs / 0.0
+
+        empty = CartesianState()
+        with self.assertRaises(RuntimeError):
+            empty / scalar
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/space/test_cartesian_state.py
+++ b/python/test/space/test_cartesian_state.py
@@ -149,11 +149,16 @@ class TestCartesianState(unittest.TestCase):
         copy2 = random.copy()
         self.assert_name_frame_data_equal(random, copy2)
 
+        copy3 = CartesianState(random)
+        self.assert_name_frame_data_equal(random, copy3)
+
         empty = CartesianState()
-        copy2 = empty
-        self.assertTrue(copy2.is_empty())
-        copy3 = empty.copy()
-        self.assertTrue(copy3.is_empty())
+        copy4 = empty
+        self.assertTrue(copy4.is_empty())
+        copy5 = CartesianState(empty)
+        self.assertTrue(copy5.is_empty())
+        copy6 = empty.copy()
+        self.assertTrue(copy6.is_empty())
 
     def test_get_set_fields(self):
         cs = CartesianState("test")

--- a/python/test/space/test_cartesian_state.py
+++ b/python/test/space/test_cartesian_state.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from state_representation import CartesianState, StateType, CartesianStateVariable
+from state_representation import State, CartesianState, StateType, CartesianStateVariable
 
 from .test_spatial_state import SPATIAL_STATE_METHOD_EXPECTS
 from ..test_state import STATE_METHOD_EXPECTS
@@ -104,6 +104,7 @@ class TestCartesianState(unittest.TestCase):
 
     def test_constructors(self):
         empty1 = CartesianState()
+        self.assertTrue(isinstance(empty1, State))
         self.assertEqual(type(empty1), CartesianState)
         self.assertEqual(empty1.get_type(), StateType.CARTESIANSTATE)
         self.assert_name_empty_frame_equal(empty1, "", True, "world")
@@ -123,6 +124,7 @@ class TestCartesianState(unittest.TestCase):
 
     def test_identity_initialization(self):
         identity = CartesianState().Identity("test")
+        self.assertTrue(isinstance(identity, State))
         self.assertFalse(identity.is_empty())
         self.assertAlmostEqual(np.linalg.norm(identity.get_position()), 0)
         self.assertAlmostEqual(np.linalg.norm(identity.get_orientation()), 1)
@@ -133,6 +135,7 @@ class TestCartesianState(unittest.TestCase):
 
     def test_random_initialization(self):
         random = CartesianState().Random("test")
+        self.assertTrue(isinstance(random, State))
         self.assertFalse(random.is_empty())
         self.assertTrue(np.linalg.norm(random.get_position()) > 0)
         self.assertAlmostEqual(np.linalg.norm(random.get_orientation()), 1)

--- a/python/test/space/test_spatial_state.py
+++ b/python/test/space/test_spatial_state.py
@@ -33,6 +33,12 @@ class TestState(unittest.TestCase):
         self.assertEqual(state2.get_reference_frame(), "robot")
         self.assertFalse(state2.is_empty())
 
+        state3 = SpatialState(state2)
+        self.assertEqual(state2.get_type(), state3.get_type())
+        self.assertEqual(state2.get_name(), state3.get_name())
+        self.assertEqual(state2.get_reference_frame(), state3.get_reference_frame())
+        self.assertEqual(state2.is_empty(), state3.is_empty())
+
     def test_compatibility(self):
         state1 = SpatialState(StateType.CARTESIANSTATE, "test", "robot", True)
         state2 = SpatialState(StateType.STATE, "test")

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_state.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_state.cpp
@@ -2,15 +2,35 @@
 
 #include "state_representation/space/cartesian/CartesianState.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"
+#include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/exceptions/NotImplementedException.hpp"
 
 using namespace state_representation;
 
+TEST(CartesianStateTest, Constructors) {
+  CartesianState empty1;
+  EXPECT_EQ(empty1.get_name(), "none");
+  EXPECT_EQ(empty1.get_type(), StateType::CARTESIANSTATE);
+  EXPECT_TRUE(empty1.is_empty());
+  EXPECT_EQ(empty1.get_reference_frame(), "world");
+  EXPECT_EQ(empty1.data().norm(), 1);
+
+  CartesianState empty2("test");
+  EXPECT_EQ(empty2.get_name(), "test");
+  EXPECT_TRUE(empty2.is_empty());
+  EXPECT_EQ(empty2.get_reference_frame(), "world");
+  EXPECT_EQ(empty2.data().norm(), 1);
+
+  CartesianState empty3("test", "reference");
+  EXPECT_EQ(empty3.get_name(), "test");
+  EXPECT_TRUE(empty3.is_empty());
+  EXPECT_EQ(empty3.get_reference_frame(), "reference");
+  EXPECT_EQ(empty3.data().norm(), 1);
+}
+
 TEST(CartesianStateTest, IdentityInitialization) {
   CartesianState identity = CartesianState::Identity("test");
-  // the joint state should not be considered empty (as it is properly initialized)
   EXPECT_FALSE(identity.is_empty());
-  // all data should be zero except for orientation that should be identity
   EXPECT_EQ(identity.get_position().norm(), 0);
   EXPECT_EQ(identity.get_orientation().norm(), 1);
   EXPECT_EQ(identity.get_orientation().w(), 1);
@@ -21,67 +41,167 @@ TEST(CartesianStateTest, IdentityInitialization) {
 
 TEST(CartesianStateTest, RandomStateInitialization) {
   CartesianState random = CartesianState::Random("test");
-  // all data should be random (non 0)
   EXPECT_NE(random.get_position().norm(), 0);
-  EXPECT_NE(abs(random.get_orientation().w()), 0);
-  EXPECT_NE(abs(random.get_orientation().x()), 0);
-  EXPECT_NE(abs(random.get_orientation().y()), 0);
-  EXPECT_NE(abs(random.get_orientation().z()), 0);
+  EXPECT_EQ(random.get_orientation().norm(), 1);
+  EXPECT_NE(random.get_orientation().w(), 0);
+  EXPECT_NE(random.get_orientation().x(), 0);
+  EXPECT_NE(random.get_orientation().y(), 0);
+  EXPECT_NE(random.get_orientation().z(), 0);
   EXPECT_NE(random.get_twist().norm(), 0);
   EXPECT_NE(random.get_accelerations().norm(), 0);
   EXPECT_NE(random.get_wrench().norm(), 0);
 }
 
-TEST(CartesianStateTest, CopyState) {
-  CartesianState state1 = CartesianState::Random("test");
-  CartesianState state2(state1);
-  EXPECT_EQ(state1.get_name(), state2.get_name());
-  EXPECT_EQ(state1.get_reference_frame(), state2.get_reference_frame());
-  EXPECT_TRUE(state1.data().isApprox(state2.data()));
-  CartesianState state3 = state1;
-  EXPECT_EQ(state1.get_name(), state3.get_name());
-  EXPECT_EQ(state1.get_reference_frame(), state3.get_reference_frame());
-  EXPECT_TRUE(state1.data().isApprox(state3.data()));
+TEST(CartesianStateTest, CopyConstructor) {
+  CartesianState random = CartesianState::Random("test");
+  CartesianState copy1(random);
+  EXPECT_EQ(random.get_name(), copy1.get_name());
+  EXPECT_EQ(random.get_reference_frame(), copy1.get_reference_frame());
+  EXPECT_EQ(random.data(), copy1.data());
 
-  CartesianState state4;
-  EXPECT_TRUE(state4.is_empty());
-  CartesianState state5 = state4;
-  EXPECT_TRUE(state5.is_empty());
+  CartesianState copy2 = random;
+  EXPECT_EQ(random.get_name(), copy2.get_name());
+  EXPECT_EQ(random.get_reference_frame(), copy2.get_reference_frame());
+  EXPECT_EQ(random.data(), copy2.data());
+
+  CartesianState copy3 = random.copy();
+  EXPECT_EQ(random.get_name(), copy3.get_name());
+  EXPECT_EQ(random.get_reference_frame(), copy3.get_reference_frame());
+  EXPECT_EQ(random.data(), copy3.data());
+
+  CartesianState empty;
+  CartesianState copy4(empty);
+  EXPECT_TRUE(copy4.is_empty());
+  CartesianState copy5 = empty;
+  EXPECT_TRUE(copy5.is_empty());
+  CartesianState copy6 = empty.copy();
+  EXPECT_TRUE(copy6.is_empty());
 }
 
-TEST(CartesianStateTest, GetData) {
-  CartesianState cs = CartesianState::Random("test");
-  Eigen::VectorXd concatenated_state(25);
-  concatenated_state << cs.get_pose(), cs.get_twist(), cs.get_accelerations(), cs.get_wrench();
-  EXPECT_TRUE(concatenated_state.isApprox(cs.data()));
+TEST(CartesianStateTest, GetSetFields) {
+  CartesianState cs("test");
+
+  // name
+  cs.set_name("robot");
+  EXPECT_EQ(cs.get_name(), "robot");
+  EXPECT_EQ(cs.get_reference_frame(), "world");
+  cs.set_reference_frame("base");
+  EXPECT_EQ(cs.get_reference_frame(), "base");
+
+  // position
+  std::vector<double> position{1, 2, 3};
+  cs.set_position(position);
+  for (std::size_t i = 0; i < position.size(); ++i) {
+    EXPECT_EQ(cs.get_position()(i), position.at(i));
+  }
+  cs.set_position(1.1, 2.2, 3.3);
+  EXPECT_EQ(Eigen::Vector3d(1.1, 2.2, 3.3), cs.get_position());
+
+  // orientation
+  Eigen::Vector4d orientation_vec = Eigen::Vector4d::Random().normalized();
+  cs.set_orientation(orientation_vec);
+  for (auto i = 0; i < orientation_vec.size(); ++i) {
+    EXPECT_FLOAT_EQ(cs.get_orientation_coefficients()(i), orientation_vec(i));
+  }
+  Eigen::Quaterniond random_orientation = Eigen::Quaterniond::UnitRandom();
+  std::vector<double>
+      orientation{random_orientation.w(), random_orientation.x(), random_orientation.y(), random_orientation.z()};
+  cs.set_orientation(orientation);
+  EXPECT_EQ(random_orientation.coeffs(), cs.get_orientation().coeffs());
+  EXPECT_THROW(cs.set_orientation(position), exceptions::IncompatibleSizeException);
+
+  auto matrix = cs.get_transformation_matrix();
+  Eigen::Vector3d trans = matrix.topRightCorner<3, 1>();
+  Eigen::Matrix3d rot = matrix.topLeftCorner<3, 3>();
+  Eigen::Vector4d bottom = matrix.bottomLeftCorner<1, 4>();
+  EXPECT_EQ(trans, cs.get_position());
+  EXPECT_EQ(rot, random_orientation.toRotationMatrix());
+  EXPECT_EQ(bottom, Eigen::Vector4d(0, 0, 0, 1));
+
+  // pose
+  EXPECT_THROW(cs.set_pose(std::vector<double>(8)), exceptions::IncompatibleSizeException);
+
+  // twist
+  Eigen::Vector3d linear_velocity = Eigen::Vector3d::Random();
+  cs.set_linear_velocity(linear_velocity);
+  EXPECT_EQ(cs.get_linear_velocity(), linear_velocity);
+  Eigen::Vector3d angular_velocity = Eigen::Vector3d::Random();
+  cs.set_angular_velocity(angular_velocity);
+  EXPECT_EQ(cs.get_angular_velocity(), angular_velocity);
+  Eigen::VectorXd twist = Eigen::VectorXd::Random(6);
+  cs.set_twist(twist);
+  EXPECT_EQ(cs.get_twist(), twist);
+
+  // wrench
+  Eigen::Vector3d force = Eigen::Vector3d::Random();
+  cs.set_force(force);
+  EXPECT_EQ(cs.get_force(), force);
+  Eigen::Vector3d torque = Eigen::Vector3d::Random();
+  cs.set_torque(torque);
+  EXPECT_EQ(cs.get_torque(), torque);
+  Eigen::VectorXd wrench = Eigen::VectorXd::Random(6);
+  cs.set_wrench(wrench);
+  EXPECT_EQ(cs.get_wrench(), wrench);
+
+//  EXPECT_THROW(cs.set_position(Eigen::VectorXd::Zero(4)), exceptions::IncompatibleSizeException);
+//  EXPECT_THROW(cs.set_twist(Eigen::VectorXd::Zero(5)), exceptions::IncompatibleSizeException);
+//  EXPECT_THROW(cs.set_wrench(Eigen::VectorXd::Zero(7)), exceptions::IncompatibleSizeException);
+
+  cs.set_zero();
+  EXPECT_EQ(cs.data().norm(), 1);
+  EXPECT_EQ(cs.is_empty(), false);
+  cs.set_empty();
+  EXPECT_EQ(cs.is_empty(), true);
 }
 
-TEST(CartesianStateTest, SetData) {
+TEST(CartesianStateTest, Compatibility) {
+  CartesianState cs1("test");
+  CartesianState cs2("robot");
+  CartesianState cs3("robot", "test");
+  CartesianState cs4("test", "robot");
+
+  EXPECT_FALSE(cs1.is_compatible(cs2));
+  EXPECT_FALSE(cs1.is_compatible(cs3));
+  EXPECT_FALSE(cs1.is_compatible(cs4));
+}
+
+TEST(CartesianStateTest, SetZero) {
+  CartesianState random1 = CartesianState::Random("test");
+  random1.initialize();
+  EXPECT_EQ(random1.data().norm(), 1);
+
+  CartesianState random2 = CartesianState::Random("test");
+  random2.set_zero();
+  EXPECT_EQ(random2.data().norm(), 1);
+}
+
+TEST(CartesianStateTest, GetSetData) {
   CartesianState cs1 = CartesianState::Identity("test");
   CartesianState cs2 = CartesianState::Random("test");
-  cs1.set_data(cs2.data());
-  EXPECT_TRUE(cs2.data().isApprox(cs1.data()));
+  Eigen::VectorXd concatenated_state(25);
+  concatenated_state << cs1.get_pose(), cs1.get_twist(), cs1.get_accelerations(), cs1.get_wrench();
+  EXPECT_EQ(concatenated_state, cs1.data());
+  for (std::size_t i = 0; i < 25; ++i) {
+    EXPECT_FLOAT_EQ(concatenated_state.array()(i), cs1.array()(i));
+  }
 
+  cs1.set_data(cs2.data());
+  EXPECT_EQ(cs1.data(), cs2.data());
+
+  cs2 = CartesianState::Random("test");
   auto state_vec = cs2.to_std_vector();
   cs1.set_data(state_vec);
-  for (std::size_t j = 0; j < state_vec.size(); ++j) {
-    EXPECT_FLOAT_EQ(state_vec.at(j), cs1.data()(j));
+  for (std::size_t i = 0; i < state_vec.size(); ++i) {
+    EXPECT_FLOAT_EQ(state_vec.at(i), cs1.data()(i));
   }
-  EXPECT_THROW(cs1.set_data(Eigen::Vector3d::Zero()), exceptions::IncompatibleSizeException);
+  EXPECT_THROW(cs1.set_data(Eigen::Vector2d::Zero()), exceptions::IncompatibleSizeException);
 }
 
-TEST(CartesianStateTest, CartesianStateToStdVector) {
-  CartesianState cs = CartesianState::Random("test");
-  std::vector<double> vec_data = cs.to_std_vector();
-  for (size_t i = 0; i < vec_data.size(); ++i) {
-    EXPECT_EQ(cs.data()(i), vec_data[i]);
-  }
-}
-
-TEST(CartesianStateTest, TestStateClamping) {
+TEST(CartesianStateTest, ClampVariable) {
   CartesianState state = CartesianState::Identity("test");
   EXPECT_THROW(state.clamp_state_variable(1, CartesianStateVariable::ORIENTATION), exceptions::NotImplementedException);
   EXPECT_THROW(state.clamp_state_variable(1, CartesianStateVariable::POSE), exceptions::NotImplementedException);
+//  EXPECT_THROW(state.clamp_state_variable(1, CartesianStateVariable::ALL), exceptions::NotImplementedException);
   Eigen::Vector3d position(-2.0, 1, 5);
   state.set_position(position);
   state.clamp_state_variable(10.0, CartesianStateVariable::POSITION);
@@ -90,42 +210,71 @@ TEST(CartesianStateTest, TestStateClamping) {
   EXPECT_EQ(state.get_position().norm(), 3.0);
   state.clamp_state_variable(10.0, CartesianStateVariable::POSITION, 0.5);
   EXPECT_EQ(state.get_position().norm(), 0.0);
+  // TODO
 }
 
-TEST(CartesianStateTest, TestAllNorms) {
-  double tolerance = 1e-4;
-  CartesianState cs = CartesianState::Random("cs");
-  // first test all norms
+TEST(CartesianStateTest, Norms) {
+  CartesianState cs = CartesianState::Random("test");
   std::vector<double> norms = cs.norms();
   ASSERT_TRUE(norms.size() == 8);
-  EXPECT_NEAR(norms[0], cs.get_position().norm(), tolerance);
-  EXPECT_NEAR(norms[1], cs.get_orientation().norm(), tolerance);
-  EXPECT_NEAR(norms[2], cs.get_linear_velocity().norm(), tolerance);
-  EXPECT_NEAR(norms[3], cs.get_angular_velocity().norm(), tolerance);
-  EXPECT_NEAR(norms[4], cs.get_linear_acceleration().norm(), tolerance);
-  EXPECT_NEAR(norms[5], cs.get_angular_acceleration().norm(), tolerance);
-  EXPECT_NEAR(norms[6], cs.get_force().norm(), tolerance);
-  EXPECT_NEAR(norms[7], cs.get_torque().norm(), tolerance);
+  EXPECT_FLOAT_EQ(norms[0], cs.get_position().norm());
+  EXPECT_FLOAT_EQ(norms[1], cs.get_orientation().norm());
+  EXPECT_FLOAT_EQ(norms[2], cs.get_linear_velocity().norm());
+  EXPECT_FLOAT_EQ(norms[3], cs.get_angular_velocity().norm());
+  EXPECT_FLOAT_EQ(norms[4], cs.get_linear_acceleration().norm());
+  EXPECT_FLOAT_EQ(norms[5], cs.get_angular_acceleration().norm());
+  EXPECT_FLOAT_EQ(norms[6], cs.get_force().norm());
+  EXPECT_FLOAT_EQ(norms[7], cs.get_torque().norm());
 }
 
-TEST(CartesianStateTest, TestNormalize) {
-  double tolerance = 1e-4;
-  CartesianState cs = CartesianState::Random("cs");
+TEST(CartesianStateTest, Normalize) {
+  CartesianState cs = CartesianState::Random("test");
+  auto normalized = cs.normalized();
+  std::vector<double> norms1 = normalized.norms();
+  for (double n: norms1) {
+    EXPECT_FLOAT_EQ(n, 1.0);
+  }
   cs.normalize();
-  std::vector<double> norms = cs.norms();
-  for (double n: norms) {
-    EXPECT_NEAR(n, 1.0, tolerance);
+  std::vector<double> norms2 = cs.norms();
+  for (double n: norms2) {
+    EXPECT_FLOAT_EQ(n, 1.0);
   }
 }
 
-TEST(CartesianStateTest, TestNormalized) {
-  double tolerance = 1e-4;
-  CartesianState cs = CartesianState::Random("cs");
-  CartesianState csn = cs.normalized();
-  std::vector<double> norms = csn.norms();
-  for (double n: norms) {
-    EXPECT_NEAR(n, 1.0, tolerance);
-  }
+TEST(CartesianStateTest, Distance) {
+  CartesianState empty;
+  CartesianState cs1 = CartesianState::Random("test");
+  CartesianState cs2 = CartesianState::Random("test", "robot");
+  EXPECT_THROW(empty.dist(cs1), exceptions::EmptyStateException);
+  EXPECT_THROW(cs1.dist(empty), exceptions::EmptyStateException);
+  EXPECT_THROW(cs1.dist(cs2), exceptions::IncompatibleReferenceFramesException);
+
+  Eigen::VectorXd data1 = Eigen::VectorXd::Random(25);
+  cs1.set_data(data1);
+  CartesianState cs3 = CartesianState("test");
+  Eigen::VectorXd data3 = Eigen::VectorXd::Random(25);
+  cs3.set_data(data3);
+
+  double pos_dist = (data1.head(3) - data3.head(3)).norm();
+  double inner_product = cs1.get_orientation().dot(cs3.get_orientation());
+  double orient_dist = acos(std::min(1.0, std::max(-1.0, 2 * inner_product * inner_product - 1)));
+  double lin_vel_dist = (data1.segment(7, 3) - data3.segment(7, 3)).norm();
+  double ang_vel_dist = (data1.segment(10, 3) - data3.segment(10, 3)).norm();
+  double lin_acc_dist = (data1.segment(13, 3) - data3.segment(13, 3)).norm();
+  double ang_acc_dist = (data1.segment(16, 3) - data3.segment(16, 3)).norm();
+  double force_dist = (data1.segment(19, 3) - data3.segment(19, 3)).norm();
+  double torque_dist = (data1.segment(22, 3) - data3.segment(22, 3)).norm();
+  double total_dist =
+      pos_dist + orient_dist + lin_vel_dist + ang_vel_dist + lin_acc_dist + ang_acc_dist + force_dist + torque_dist;
+
+  EXPECT_FLOAT_EQ(cs1.dist(cs3, CartesianStateVariable::POSITION), pos_dist);
+  EXPECT_FLOAT_EQ(cs1.dist(cs3, CartesianStateVariable::ORIENTATION), orient_dist);
+  EXPECT_FLOAT_EQ(cs1.dist(cs3, CartesianStateVariable::POSE), pos_dist + orient_dist);
+  EXPECT_FLOAT_EQ(cs1.dist(cs3, CartesianStateVariable::TWIST), lin_vel_dist + ang_vel_dist);
+  EXPECT_FLOAT_EQ(cs1.dist(cs3, CartesianStateVariable::ACCELERATIONS), lin_acc_dist + ang_acc_dist);
+  EXPECT_FLOAT_EQ(cs1.dist(cs3, CartesianStateVariable::WRENCH), force_dist + torque_dist);
+  EXPECT_FLOAT_EQ(cs1.dist(cs3, CartesianStateVariable::ALL), total_dist);
+  EXPECT_FLOAT_EQ(cs1.dist(cs3), cs3.dist(cs1));
 }
 
 TEST(CartesianStateTest, TestScalarDivison) {


### PR DESCRIPTION
I've been sitting on this quite long and I'm happy to push this finally.
I improved the test coverage of CartesianState by adding a test for all operations / functions (except `inverse` of course...) and added the equivalent tests in Python too.

Only problem for Python is that I'm not sure to what an Eigen::Quaternion translates in python and with what functions I should do the tests.

Let me know if you'd prefer tests with explicit test cases with hardcoded numbers.