### PR TITLE
Add build testing option to clproto install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release Versions:
 - Add Python bindings for Parameter class (#209)
 - Add Python bindings for clproto encode / decode of Parameter class (#214)
 - Improve CartesianState tests in C++ and Python (#213)
+- Add build testing option to clproto install (#216)
 
 ### Pending TODOs for the next release
 

--- a/protocol/clproto_cpp/CMakeLists.txt
+++ b/protocol/clproto_cpp/CMakeLists.txt
@@ -3,6 +3,7 @@ project(clproto VERSION 4.0.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
+include(FindProtobuf)
 find_package(Protobuf REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_library(state_representation REQUIRED)
@@ -38,7 +39,7 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/include/clproto.h)
-target_link_libraries(${PROJECT_NAME} PUBLIC protobuf state_representation PRIVATE ${PROJECT_NAME}_bindings)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${PROTOBUF_LIBRARY} state_representation PRIVATE ${PROJECT_NAME}_bindings)
 
 install(TARGETS ${PROJECT_NAME}
     PUBLIC_HEADER DESTINATION include

--- a/protocol/install.sh
+++ b/protocol/install.sh
@@ -4,6 +4,7 @@ PROTOBUF_DIR="${SCRIPT_DIR}"/protobuf
 CLPROTO_DIR="${SCRIPT_DIR}"/clproto_cpp
 
 INSTALL_DESTINATION="/usr/local"
+BUILD_TESTING="OFF"
 AUTO_INSTALL=""
 BINDINGS_ONLY=false
 PROTOBUF_VERSION="3.17.0"
@@ -21,6 +22,8 @@ Options:
 
   -d, --dir [path]         Configure the installation directory
                            (default: ${INSTALL_DESTINATION}).
+
+  --build-tests            Build the unittest targets.
 
   --clean-bindings         Clean any previously generated protobuf
                            bindings.
@@ -75,7 +78,7 @@ function install_state_representation() {
 function install_clproto() {
   cd "${CLPROTO_DIR}" && mkdir -p build && cd build || exit 1
 
-  cmake -DCMAKE_BUILD_TYPE=Release \
+  cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING="${BUILD_TESTING}" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_DESTINATION}" .. || exit 1
 
   make -j && make install || exit 1
@@ -106,6 +109,10 @@ while [ "$#" -gt 0 ]; do
     ;;
   --bindings-only)
     BINDINGS_ONLY=true
+    shift 1
+    ;;
+  --build-tests)
+    BUILD_TESTING="ON"
     shift 1
     ;;
   --clean-bindings)


### PR DESCRIPTION
As I've mentioned, I could not build the clproto tests locally on the franka PC due to linking errors. The solution presented below in the CMakeLists resolves this issue for clproto as well as for franka lwi,  so I think it's fair to put that here. I additionally added a flag to build the tests in the clproto install script, same as in the source install script.