### PR TITLE
Add the State set_timestamp function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release Versions:
 - Improve CartesianState tests in C++ and Python (#213)
 - Add build testing option to clproto install (#216)
 - Add method to set a joint state by name or index of the joint (#217)
+- Add the `set_timestamp` method to the `State` base class (#218)
 
 ### Pending TODOs for the next release
 

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -20,6 +21,13 @@ namespace clproto {
  * ::unpack_fields() methods
  */
 typedef std::size_t field_length_t;
+
+/**
+ * @typedef timestamp_duration_t
+ * @brief Duration type to use when representing
+ * chrono timestamps as integer count since epoch
+ */
+typedef std::chrono::nanoseconds timestamp_duration_t;
 
 /**
  * @class DecodingException

--- a/protocol/clproto_cpp/include/clproto/encoders.h
+++ b/protocol/clproto_cpp/include/clproto/encoders.h
@@ -9,6 +9,7 @@
 #include <state_representation/robot/JointState.hpp>
 #include <state_representation/parameters/Parameter.hpp>
 
+#include "clproto.h"
 #include "state_representation/state_message.pb.h"
 
 namespace clproto {

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -190,9 +190,8 @@ bool decode(const std::string& msg, State& obj) {
 
     auto state = message.state();
     obj = State(decoder(state.type()), state.name(), state.empty());
-
-    //TODO: (maybe) add set_timestamp method to State and add decoder for int to chrono
-    //obj.set_timestamp(state.timestamp());
+    std::chrono::time_point<std::chrono::steady_clock> timepoint(timestamp_duration_t(state.timestamp()));
+    obj.set_timestamp(timepoint);
 
     return true;
   } catch (...) {

--- a/protocol/clproto_cpp/src/encoders.cpp
+++ b/protocol/clproto_cpp/src/encoders.cpp
@@ -17,7 +17,8 @@ proto::State encoder(const State& state) {
   message.set_name(state.get_name());
   message.set_type(encoder(state.get_type()));
   message.set_empty(state.is_empty());
-  message.set_timestamp(state.get_timestamp().time_since_epoch().count());
+  auto timestamp = std::chrono::duration_cast<timestamp_duration_t>(state.get_timestamp().time_since_epoch());
+  message.set_timestamp(timestamp.count());
   return message;
 }
 

--- a/protocol/clproto_cpp/test/tests/test_messages.cpp
+++ b/protocol/clproto_cpp/test/tests/test_messages.cpp
@@ -17,8 +17,10 @@ TEST(MessageProtoTest, EncodeDecodeState) {
   EXPECT_TRUE(clproto::decode(msg, recv_state));
 
   EXPECT_EQ(send_state.is_empty(), recv_state.is_empty());
-  EXPECT_EQ(recv_state.get_type(), StateType::STATE);
+  EXPECT_EQ(send_state.get_type(), recv_state.get_type());
   EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_EQ(send_state.get_timestamp().time_since_epoch().count(),
+            recv_state.get_timestamp().time_since_epoch().count());
 }
 
 TEST(MessageProtoTest, DecodeInvalidString) {

--- a/protocol/protobuf/proto/state_representation/state.proto
+++ b/protocol/protobuf/proto/state_representation/state.proto
@@ -34,5 +34,5 @@ message State {
   string name = 1;
   StateType type = 2;
   bool empty = 3;
-  int64 timestamp = 4;
+  int64 timestamp = 4;  // timestamp is encoded as nanoseconds since the system steady_clock epoch
 }

--- a/python/source/state_representation/bind_state.cpp
+++ b/python/source/state_representation/bind_state.cpp
@@ -43,6 +43,7 @@ void state(py::module_& m) {
   c.def("set_empty", &State::set_empty, "Setter of the empty attribute", "empty"_a=true);
   c.def("set_filled", &State::set_filled, "Setter of the empty attribute to false and also reset the timestamp");
   c.def("get_timestamp", &State::get_timestamp, "Getter of the timestamp attribute");
+  c.def("set_timestamp", &State::set_timestamp, "Setter of the timestamp attribute");
   c.def("reset_timestamp", &State::reset_timestamp, "Reset the timestamp attribute to now");
   c.def("get_name", &State::get_name, "Getter of the name");
   c.def("set_name", &State::set_name, "Setter of the name");

--- a/python/test/test_state.py
+++ b/python/test/test_state.py
@@ -1,5 +1,6 @@
 import time
 import unittest
+import datetime
 
 from state_representation import State, StateType
 

--- a/python/test/test_state.py
+++ b/python/test/test_state.py
@@ -69,6 +69,10 @@ class TestState(unittest.TestCase):
         self.assertTrue(state.is_deprecated(0.1))
         state.reset_timestamp()
         self.assertFalse(state.is_deprecated(0.1))
+        time.sleep(0.2)
+        self.assertTrue(state.is_deprecated(0.1))
+        state.set_timestamp(time.localtime())
+        self.assertFalse(state.is_deprecated(0.1))
 
 
 if __name__ == '__main__':

--- a/python/test/test_state.py
+++ b/python/test/test_state.py
@@ -9,6 +9,7 @@ STATE_METHOD_EXPECTS = [
     'set_empty',
     'set_filled',
     'get_timestamp',
+    'set_timestamp',
     'reset_timestamp',
     'get_name',
     'set_name',

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -117,6 +117,12 @@ public:
   const std::chrono::time_point<std::chrono::steady_clock>& get_timestamp() const;
 
   /**
+   * @brief Setter of the timestamp attribute
+   * @param timepoint the new value for the timestamp
+   */
+  void set_timestamp(const std::chrono::time_point<std::chrono::steady_clock>& timepoint);
+
+  /**
    * @brief Reset the timestamp attribute to now
    */
   void reset_timestamp();
@@ -208,6 +214,10 @@ inline void State::set_filled() {
 
 inline const std::chrono::time_point<std::chrono::steady_clock>& State::get_timestamp() const {
   return this->timestamp_;
+}
+
+inline void State::set_timestamp(const std::chrono::time_point<std::chrono::steady_clock>& timepoint) {
+  this->timestamp_ = timepoint;
 }
 
 inline void State::reset_timestamp() {

--- a/source/state_representation/test/tests/test_state.cpp
+++ b/source/state_representation/test/tests/test_state.cpp
@@ -52,6 +52,10 @@ TEST(StateTest, Timestamp) {
   EXPECT_TRUE(state.is_deprecated(std::chrono::milliseconds(100)));
   state.reset_timestamp();
   EXPECT_FALSE(state.is_deprecated(std::chrono::milliseconds(100)));
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_TRUE(state.is_deprecated(std::chrono::milliseconds(100)));
+  state.set_timestamp(std::chrono::steady_clock::now());
+  EXPECT_FALSE(state.is_deprecated(std::chrono::milliseconds(100)));
 }
 
 TEST(StateTest, Swap) {


### PR DESCRIPTION
This PR adds the `set_timestamp` function in `State` which I would like to use downstream when receiving timed messages. Also, I have realized the `timestamp` uses a `steady_clock` which is different to how `ros` handles time (those would be `system_clock`). I think this is still acceptable as we can convert between the two. But we have to acknowledge that properly.