### PR TITLE
Lightweight image to copy protobuf files from

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,7 +9,29 @@ on:
 
 jobs:
 
+  build-publish-proto-dependencies:
+    runs-on: ubuntu-latest
+    name: Build and publish proto dependencies image
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Build image
+        run: |
+          docker build . --file ./Dockerfile.proto  --tag proto-dependencies
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_NAME=${{ github.repository }}/proto-dependencies:latest
+          IMAGE_NAME=${IMAGE_NAME/_/-}
+          docker tag proto-dependencies ghcr.io/${IMAGE_NAME}
+          docker push ghcr.io/${IMAGE_NAME}
+
   build-publish-development-dependencies:
+    needs: build-publish-proto-dependencies
     runs-on: ubuntu-latest
     name: Build and publish development dependencies image
     steps:

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -50,7 +50,6 @@ RUN rm -rf /tmp/*
 
 
 FROM core-build-dependencies as google-dependencies
-ENV PROTOBUF_VERSION 3.17.0
 
 RUN apt-get update && apt-get install -y \
     libgtest-dev \
@@ -62,19 +61,6 @@ WORKDIR /tmp/gtest_build
 RUN cmake /usr/src/gtest \
     && make \
     && cp lib/* /usr/local/lib || cp *.a /usr/local/lib
-
-# install protobuf
-WORKDIR /tmp
-RUN wget -O protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz \
-    https://github.com/protocolbuffers/protobuf/releases/download/v"${PROTOBUF_VERSION}"/protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz \
-    && tar -xzf protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz \
-    && rm protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz
-
-WORKDIR /tmp/protobuf-"${PROTOBUF_VERSION}"
-RUN ./autogen.sh \
-    &&./configure \
-    && make \
-    && make install
 
 WORKDIR /home
 RUN rm -rf /tmp/*
@@ -103,8 +89,8 @@ RUN pip3 install numpy setuptools pybind11
 
 # install google dependencies
 COPY --from=google-dependencies /usr/include/gtest /usr/include/gtest
-COPY --from=google-dependencies /usr/local/include/google /usr/local/include/google
+COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies /usr/local/include/google /usr/local/include/google
 COPY --from=google-dependencies /usr/local/lib/libgtest* /usr/local/lib/
-COPY --from=google-dependencies /usr/local/lib/libproto* /usr/local/lib/
-COPY --from=google-dependencies /usr/local/bin/protoc /usr/local/bin
+COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies /usr/local/lib/libproto* /usr/local/lib/
+COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies /usr/local/bin/protoc /usr/local/bin
 RUN ldconfig

--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -1,0 +1,32 @@
+FROM ubuntu:20.04 AS build-stage
+ARG PROTOBUF_VERSION=3.17.0
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    cmake \
+    g++ \
+    gcc \
+    libtool \
+    make \
+    wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+RUN wget -O protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz \
+    https://github.com/protocolbuffers/protobuf/releases/download/v"${PROTOBUF_VERSION}"/protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz \
+    && tar -xzf protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz \
+    && rm protobuf-cpp-"${PROTOBUF_VERSION}".tar.gz
+
+WORKDIR /tmp/protobuf-"${PROTOBUF_VERSION}"
+RUN ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install
+
+FROM ubuntu:20.04 AS google-dependencies
+COPY --from=build-stage /usr/local/include/google /usr/local/include/google
+COPY --from=build-stage /usr/local/lib/libproto* /usr/local/lib/
+COPY --from=build-stage /usr/local/bin/protoc /usr/local/bin
+RUN ldconfig


### PR DESCRIPTION
This is a small item from the backlog, and I found some time to do it. I removed the protobuf installation from the base Dockerfile and moved it into a seperate one. The resulting image is 720MB vs 2.36GB of the development-dependencies image. 

We could even move the gtest installation to the new Dockerfile but that doesn't take a lot of time so I couldn't make up my mind :smile: 