### PR TITLE
Specify fixed width type for field size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Release Versions:
 - Add build testing option to clproto install (#216)
 - Add method to set a joint state by name or index of the joint (#217)
 - Add the `set_timestamp` method to the `State` base class (#218)
+- Fix the field size type for clproto pack_fields (#222)
 
 ### Pending TODOs for the next release
 

--- a/protocol/clproto_cpp/include/clproto.h
+++ b/protocol/clproto_cpp/include/clproto.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <chrono>
 #include <stdexcept>
 #include <string>
@@ -20,7 +21,7 @@ namespace clproto {
  * and field data length in ::pack_fields() and
  * ::unpack_fields() methods
  */
-typedef std::size_t field_length_t;
+typedef uint32_t field_length_t;
 
 /**
  * @typedef timestamp_duration_t

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -65,8 +65,6 @@ ParameterMessageType check_parameter_message_type(const std::string& msg) {
   return ParameterMessageType::UNKNOWN_PARAMETER;
 }
 
-typedef std::size_t field_length_t;
-
 // --- Serialization methods --- //
 
 void pack_fields(const std::vector<std::string>& fields, char* data) {


### PR DESCRIPTION
The `pack_fields` and `unpack_fields` method uses a header with entries containing the number of fields and their sizes so that it can be delimited. For simplicity, I used `size_t` as the largest indexable size, but the true size of this is actual system dependent. It is usually 8 bytes (uint64) but sometimes 4 bytes (uint32) and according to the spec may be as low as 2 bytes (uint16). This means that packing and unpacking could be inconsistent when done between platforms. In addition, the uncertainty of what `size_t` is makes dealing with the encoded packet outside of clproto (for example in python reading straight from a binary file) a bit more difficult. Finally, 

In this PR, I use `uint32_t` instead of `size_`t for the field length type when encoding packets, so that it is more reliable across systems. 32 bits is more than enough to specify the field length, since we already have a soft limit of 64 fields and 4096 bytes per fields, so it is a little more efficient than using `uint64_t`.