### PR TITLE
Fix tag generation for release docs

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -25,7 +25,7 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         shell: bash
         run: |
-          TAG="${GITHUB_REF#refs-tags/}"
+          TAG="${GITHUB_REF#refs/tags/}"
           TAG="${TAG/\//-}"
           mkdir -p doxygen/docs/versions
           sudo mv doxygen/docs/html doxygen/docs/versions/${TAG}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Release Versions:
 - [2.0.0](#200)
 - [1.0.0](#100)
 
+## Upcoming changes (in development)
+- Fix tag generation for release docs (#225)
+
+### Pending TODOs for the next release
+
+- Including a quaternion extension (numpy-quaternion, pyquaternion, ...)
+for binding the Eigen::Quaternion to a specific object in Python.
+
 ## 4.1.0
 
 Version 4.1.0 contains a few improvements to the behaviour and usage of the libraries,


### PR DESCRIPTION
The GITHUB_REF for a release event is actually `refs/tags/vXXX` and not `refs-tags/vXXX` which is why the doc generation for a new release always failed. This should be fixed now. Tested on my fork of control libraries