### PR TITLE
Add static method to create Parameter pointer

### DIFF
--- a/source/state_representation/include/state_representation/parameters/Event.hpp
+++ b/source/state_representation/include/state_representation/parameters/Event.hpp
@@ -3,12 +3,13 @@
 #include "state_representation/parameters/Predicate.hpp"
 
 namespace state_representation {
+
 /**
  * @class Event
  * @brief An event is a predicate with memory. Its purpose is
  * to be true only once and change value only when the underlying
  * predicate has changed from true to false and back to true
- * since last reading
+ * since last reading.
  */
 class Event : public Predicate {
 private:
@@ -16,7 +17,7 @@ private:
 
 public:
   /**
-   * @brief Constructor with name of the predicate and default false value
+   * @brief Constructor with name of the predicate and default false value.
    */
   explicit Event(const std::string& name);
 
@@ -27,24 +28,24 @@ public:
   bool read_value();
 
   /**
-   * @brief Setter of the value attribute
-   * @param the new value attribute
+   * @brief Setter of the value attribute.
+   * @param value The new value attribute
    */
   void set_value(const bool& value) override;
 
   /**
    * @brief Getter of the previous value. Does not
-   * affect the behavior of the event (as opposed to read_value)
+   * affect the behavior of the event (as opposed to read_value).
    */
   bool get_previous_value() const;
 
   /**
-    * @brief Overload the ostream operator for printing
-    * @param os the ostream to happened the string representing the State to
-    * @param predicate the Predicate to print
-    * @return the appended ostream
+    * @brief Overload the ostream operator for printing.
+    * @param os The ostream to append the string representing the Event to
+    * @param predicate The Event to print
+    * @return The appended ostream
      */
-  friend std::ostream& operator<<(std::ostream& os, const Predicate& predicate);
+  friend std::ostream& operator<<(std::ostream& os, const Event& event);
 };
 
 inline bool Event::read_value() {

--- a/source/state_representation/include/state_representation/parameters/Parameter.hpp
+++ b/source/state_representation/include/state_representation/parameters/Parameter.hpp
@@ -1,92 +1,101 @@
 #pragma once
 
+#include <memory>
+
 #include "state_representation/parameters/ParameterInterface.hpp"
 
 namespace state_representation {
-template <typename T>
+
+template<typename T>
 class Parameter : public ParameterInterface {
 private:
-  T value;///< Value of the parameter
+  T value_;///< Value of the parameter
 
 public:
   /**
-   * @brief Constructor with name of the parameter
+   * @brief Constructor with name of the parameter.
+   * @param name The name of the parameter
    */
   explicit Parameter(const std::string& name);
 
   /**
-   * @brief Constructor with a value
-   * @param name the name of the parameter
-   * @param value value of the parameter
+   * @brief Constructor with a name and a value.
+   * @param name The name of the parameter
+   * @param value The value of the parameter
    */
   explicit Parameter(const std::string& name, const T& value);
 
   /**
    * @brief Copy constructor
-   * @param parameter the parameter to copy
+   * @param parameter The parameter to copy
    */
-  template <typename U>
+  template<typename U>
   Parameter(const Parameter<U>& parameter);
 
   /**
    * @brief Conversion equality
    */
-  template <typename U>
+  template<typename U>
   Parameter<T>& operator=(const Parameter<U>& parameter);
 
   /**
-   * @brief Getter of the value attribute
-   * @return the value attribute
+   * @brief Getter of the value attribute.
+   * @return The value attribute
    */
   const T& get_value() const;
 
   /**
-   * @brief Getter of the value attribute
-   * @return the value attribute
+   * @brief Getter of the value attribute.
+   * @return The value attribute
    */
   T& get_value();
 
   /**
-   * @brief Setter of the value attribute
-   * @param the new value attribute
+   * @brief Setter of the value attribute.
+   * @param The new value attribute
    */
   virtual void set_value(const T& value);
 
   /**
-   * @brief Overload the ostream operator for printing
-   * @param os the ostream to append the string representing the State to
-   * @param parameter the Parameter to print
-   * @return the appended ostream
+   * @brief Overload the ostream operator for printing.
+   * @param os The ostream to append the string representing the State to
+   * @param parameter The Parameter to print
+   * @return The appended ostream
    */
-  template <typename U>
+  template<typename U>
   friend std::ostream& operator<<(std::ostream& os, const Parameter<U>& parameter);
 };
 
-template <typename T>
-template <typename U>
-Parameter<T>::Parameter(const Parameter<U>& parameter) : ParameterInterface(parameter), value(parameter.get_value()) {}
+template<typename T>
+template<typename U>
+Parameter<T>::Parameter(const Parameter<U>& parameter) : ParameterInterface(parameter), value_(parameter.get_value()) {}
 
-template <typename T>
-template <typename U>
+template<typename T>
+template<typename U>
 Parameter<T>& Parameter<T>::operator=(const Parameter<U>& parameter) {
   Parameter<T> temp(parameter);
   *this = temp;
   return *this;
 }
 
-template <typename T>
+template<typename T>
 inline const T& Parameter<T>::get_value() const {
-  return this->value;
+  return this->value_;
 }
 
-template <typename T>
+template<typename T>
 inline T& Parameter<T>::get_value() {
-  return this->value;
+  return this->value_;
 }
 
-template <typename T>
+template<typename T>
 inline void Parameter<T>::set_value(const T& value) {
   this->set_filled();
-  this->value = value;
+  this->value_ = value;
+}
+
+template<typename T>
+static std::shared_ptr<Parameter<T>> create_parameter_ptr(const std::string& name, const T& param_value) {
+  return std::make_shared<Parameter<T>>(Parameter<T>(name, param_value));
 }
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/parameters/ParameterInterface.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterInterface.hpp
@@ -3,31 +3,28 @@
 #include "state_representation/State.hpp"
 
 namespace state_representation {
+
 class ParameterInterface : public State {
 public:
   /**
-   * @brief Constructor with parameter name and type of the parameter
-   * @param type the type of the parameter
-   * @param name the name of the parameter
+   * @brief Constructor with parameter name and type of the parameter.
+   * @param type The type of the parameter
+   * @param name The name of the parameter
    */
   explicit ParameterInterface(const StateType& type, const std::string& name);
 
   /**
    * @brief Copy constructor
-   * @param parameter the parameter to copy
+   * @param parameter The parameter to copy
    */
   ParameterInterface(const ParameterInterface& parameter);
 
   /**
-   * @brief Copy assignement operator that have to be defined to the custom assignement operator
-   * @param state the state with value to assign
-   * @return reference to the current state with new values
+   * @brief Copy assignment operator that has to be defined
+   * to the custom assignment operator.
+   * @param state The state with value to assign
+   * @return Reference to the current state with new values
    */
   ParameterInterface& operator=(const ParameterInterface& state);
 };
-
-inline ParameterInterface& ParameterInterface::operator=(const ParameterInterface& state) {
-  State::operator=(state);
-  return (*this);
-}
 }// namespace state_representation

--- a/source/state_representation/include/state_representation/parameters/Predicate.hpp
+++ b/source/state_representation/include/state_representation/parameters/Predicate.hpp
@@ -3,6 +3,7 @@
 #include "state_representation/parameters/Parameter.hpp"
 
 namespace state_representation {
+
 /**
  * @class Predicate
  * @brief A predicate is a boolean parameter as in the logic formalism.
@@ -10,21 +11,21 @@ namespace state_representation {
 class Predicate : public Parameter<bool> {
 public:
   /**
-   * @brief Constructor with name of the predicate and default false value
+   * @brief Constructor with name of the predicate and default false value.
    */
   explicit Predicate(const std::string& name);
 
   /**
-   * @brief Constructor with a value
-   * @param name the name of the predicate
-   * @param value initial value of the predicate
+   * @brief Constructor with a value.
+   * @param name The name of the predicate
+   * @param value Initial value of the predicate
    */
   explicit Predicate(const std::string& name, bool value);
 
   /**
-   * @brief Overload the ostream operator for printing
-   * @param os the ostream to happend the string representing the State to
-   * @param predicate the Predicate to print
+   * @brief Overload the ostream operator for printing.
+   * @param os The ostream to append the string representing the Predicate to
+   * @param predicate The Predicate to print
    * @return the appended ostream
    */
   friend std::ostream& operator<<(std::ostream& os, const Predicate& predicate);

--- a/source/state_representation/src/parameters/Event.cpp
+++ b/source/state_representation/src/parameters/Event.cpp
@@ -1,6 +1,7 @@
 #include "state_representation/parameters/Event.hpp"
 
 namespace state_representation {
+
 Event::Event(const std::string& name) : Predicate(name), previous_predicate_value_(false) {}
 
 std::ostream& operator<<(std::ostream& os, const Event& event) {

--- a/source/state_representation/src/parameters/Parameter.cpp
+++ b/source/state_representation/src/parameters/Parameter.cpp
@@ -1,16 +1,18 @@
 #include "state_representation/parameters/Parameter.hpp"
+
 #include "state_representation/geometry/Ellipsoid.hpp"
 #include "state_representation/robot/JointPositions.hpp"
 #include "state_representation/space/cartesian/CartesianPose.hpp"
 
 namespace state_representation {
+
 template<>
 Parameter<int>::Parameter(const std::string& name) :
     ParameterInterface(StateType::PARAMETER_INT, name) {}
 
 template<>
 Parameter<int>::Parameter(const std::string& name, const int& value) :
-    ParameterInterface(StateType::PARAMETER_INT, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_INT, name), value_(value) {
   this->set_filled();
 }
 
@@ -20,7 +22,7 @@ Parameter<std::vector<int>>::Parameter(const std::string& name) :
 
 template<>
 Parameter<std::vector<int>>::Parameter(const std::string& name, const std::vector<int>& value) :
-    ParameterInterface(StateType::PARAMETER_INT_ARRAY, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_INT_ARRAY, name), value_(value) {
   this->set_filled();
 }
 
@@ -30,7 +32,7 @@ Parameter<double>::Parameter(const std::string& name) :
 
 template<>
 Parameter<double>::Parameter(const std::string& name, const double& value) :
-    ParameterInterface(StateType::PARAMETER_DOUBLE, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_DOUBLE, name), value_(value) {
   this->set_filled();
 }
 
@@ -40,7 +42,7 @@ Parameter<std::vector<double>>::Parameter(const std::string& name) :
 
 template<>
 Parameter<std::vector<double>>::Parameter(const std::string& name, const std::vector<double>& value) :
-    ParameterInterface(StateType::PARAMETER_DOUBLE_ARRAY, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_DOUBLE_ARRAY, name), value_(value) {
   this->set_filled();
 }
 
@@ -49,7 +51,7 @@ Parameter<bool>::Parameter(const std::string& name) : ParameterInterface(StateTy
 
 template<>
 Parameter<bool>::Parameter(const std::string& name, const bool& value) :
-    ParameterInterface(StateType::PARAMETER_BOOL, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_BOOL, name), value_(value) {
   this->set_filled();
 }
 
@@ -60,7 +62,7 @@ Parameter<std::vector<bool>>::Parameter(const std::string& name) :
 
 template<>
 Parameter<std::vector<bool>>::Parameter(const std::string& name, const std::vector<bool>& value) :
-    ParameterInterface(StateType::PARAMETER_BOOL_ARRAY, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_BOOL_ARRAY, name), value_(value) {
   this->set_filled();
 }
 
@@ -70,7 +72,7 @@ Parameter<std::string>::Parameter(const std::string& name) :
 
 template<>
 Parameter<std::string>::Parameter(const std::string& name, const std::string& value) :
-    ParameterInterface(StateType::PARAMETER_STRING, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_STRING, name), value_(value) {
   this->set_filled();
 }
 
@@ -80,7 +82,7 @@ Parameter<std::vector<std::string>>::Parameter(const std::string& name) :
 
 template<>
 Parameter<std::vector<std::string>>::Parameter(const std::string& name, const std::vector<std::string>& value) :
-    ParameterInterface(StateType::PARAMETER_STRING_ARRAY, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_STRING_ARRAY, name), value_(value) {
   this->set_filled();
 }
 
@@ -90,7 +92,7 @@ Parameter<CartesianState>::Parameter(const std::string& name) :
 
 template<>
 Parameter<CartesianState>::Parameter(const std::string& name, const CartesianState& value) :
-    ParameterInterface(StateType::PARAMETER_CARTESIANSTATE, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_CARTESIANSTATE, name), value_(value) {
   this->set_filled();
 }
 
@@ -100,7 +102,7 @@ Parameter<CartesianPose>::Parameter(const std::string& name) :
 
 template<>
 Parameter<CartesianPose>::Parameter(const std::string& name, const CartesianPose& value) :
-    ParameterInterface(StateType::PARAMETER_CARTESIANPOSE, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_CARTESIANPOSE, name), value_(value) {
   this->set_filled();
 }
 
@@ -110,7 +112,7 @@ Parameter<JointState>::Parameter(const std::string& name) :
 
 template<>
 Parameter<JointState>::Parameter(const std::string& name, const JointState& value) :
-    ParameterInterface(StateType::PARAMETER_JOINTSTATE, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_JOINTSTATE, name), value_(value) {
   this->set_filled();
 }
 
@@ -120,13 +122,13 @@ Parameter<JointPositions>::Parameter(const std::string& name) :
 
 template<>
 Parameter<JointPositions>::Parameter(const std::string& name, const JointPositions& value) :
-    ParameterInterface(StateType::PARAMETER_JOINTPOSITIONS, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_JOINTPOSITIONS, name), value_(value) {
   this->set_filled();
 }
 
 template<>
 Parameter<Ellipsoid>::Parameter(const std::string& name, const Ellipsoid& value) :
-    ParameterInterface(StateType::PARAMETER_ELLIPSOID, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_ELLIPSOID, name), value_(value) {
   this->set_filled();
 }
 
@@ -136,7 +138,7 @@ Parameter<Eigen::MatrixXd>::Parameter(const std::string& name) :
 
 template<>
 Parameter<Eigen::MatrixXd>::Parameter(const std::string& name, const Eigen::MatrixXd& value) :
-    ParameterInterface(StateType::PARAMETER_MATRIX, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_MATRIX, name), value_(value) {
   this->set_filled();
 }
 
@@ -146,7 +148,7 @@ Parameter<Eigen::VectorXd>::Parameter(const std::string& name) :
 
 template<>
 Parameter<Eigen::VectorXd>::Parameter(const std::string& name, const Eigen::VectorXd& value) :
-    ParameterInterface(StateType::PARAMETER_VECTOR, name), value(value) {
+    ParameterInterface(StateType::PARAMETER_VECTOR, name), value_(value) {
   this->set_filled();
 }
 
@@ -155,7 +157,7 @@ std::ostream& operator<<(std::ostream& os, const Parameter<T>& parameter) {
   if (parameter.is_empty()) {
     os << " Parameter " << parameter.get_name() << " is empty";
   } else {
-    os << " Parameter " << parameter.get_name() << ": " << parameter.value;
+    os << " Parameter " << parameter.get_name() << ": " << parameter.get_value();
   }
   return os;
 }
@@ -178,7 +180,7 @@ std::ostream& operator<<(std::ostream& os, const Parameter<std::vector<int>>& pa
     os << " Parameter " << parameter.get_name() << " is empty" << std::endl;
   } else {
     os << " Parameter " << parameter.get_name() << ": ";
-    for (auto& v: parameter.value) {
+    for (auto& v: parameter.get_value()) {
       os << v << " | ";
     }
     os << std::endl;
@@ -192,7 +194,7 @@ std::ostream& operator<<(std::ostream& os, const Parameter<std::vector<double>>&
     os << " Parameter " << parameter.get_name() << " is empty" << std::endl;
   } else {
     os << " Parameter " << parameter.get_name() << ": ";
-    for (auto& v: parameter.value) {
+    for (auto& v: parameter.get_value()) {
       os << v << " | ";
     }
     os << std::endl;
@@ -206,7 +208,7 @@ std::ostream& operator<<(std::ostream& os, const Parameter<std::vector<bool>>& p
     os << " Parameter " << parameter.get_name() << " is empty" << std::endl;
   } else {
     os << " Parameter " << parameter.get_name() << ": ";
-    for (auto v: parameter.value) {
+    for (auto v: parameter.get_value()) {
       os << v << " | ";
     }
     os << std::endl;
@@ -220,7 +222,7 @@ std::ostream& operator<<(std::ostream& os, const Parameter<std::vector<std::stri
     os << " Parameter " << parameter.get_name() << " is empty" << std::endl;
   } else {
     os << " Parameter " << parameter.get_name() << ": ";
-    for (auto& v: parameter.value) {
+    for (auto& v: parameter.get_value()) {
       os << v << " | ";
     }
     os << std::endl;

--- a/source/state_representation/src/parameters/ParameterInterface.cpp
+++ b/source/state_representation/src/parameters/ParameterInterface.cpp
@@ -1,7 +1,13 @@
 #include "state_representation/parameters/ParameterInterface.hpp"
 
 namespace state_representation {
+
 ParameterInterface::ParameterInterface(const StateType& type, const std::string& name) : State(type, name) {}
 
 ParameterInterface::ParameterInterface(const ParameterInterface& parameter) : State(parameter) {}
+
+inline ParameterInterface& ParameterInterface::operator=(const ParameterInterface& state) {
+  State::operator=(state);
+  return (*this);
+}
 }// namespace state_representation

--- a/source/state_representation/src/parameters/Predicate.cpp
+++ b/source/state_representation/src/parameters/Predicate.cpp
@@ -1,6 +1,7 @@
 #include "state_representation/parameters/Predicate.hpp"
 
 namespace state_representation {
+
 Predicate::Predicate(const std::string& name) : Parameter<bool>(name, false) {}
 
 Predicate::Predicate(const std::string& name, bool value) : Parameter<bool>(name, value) {}


### PR DESCRIPTION
Not that much going on here, mostly reformatting and docstring improvement.
The major change here is the addition of the static method `create_parameter_ptr` at the end of `Parameter.hpp`. It's a utility that will be very helpful to set parameters of the future DS factory. And its nice because it reduces the verbosity of creating a shared ptr of a Parameter.
It goes from `auto param = std::make_shared<Parameter<CartesianPose>>(Parameter<CartesianPose>("name", CartesianPose())` to `auto param = create_shared_ptr("name", CartesianPose)`

@AlbericLaj I'm just tagging you here so you can see how we do reviews 