### PR TITLE
Templated get_value method for Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release Versions:
 
 ## Upcoming changes (in development)
 - Fix tag generation for release docs (#225)
+- Templated get_value method for Parameter (#228)
 
 ### Pending TODOs for the next release
 

--- a/source/state_representation/include/state_representation/parameters/Parameter.hpp
+++ b/source/state_representation/include/state_representation/parameters/Parameter.hpp
@@ -68,7 +68,8 @@ public:
 
 template<typename T>
 template<typename U>
-Parameter<T>::Parameter(const Parameter<U>& parameter) : ParameterInterface(parameter), value_(parameter.get_value()) {}
+Parameter<T>::Parameter(const Parameter<U>& parameter) :
+    Parameter<T>(parameter.get_name(), static_cast<T>(parameter.get_value())) {}
 
 template<typename T>
 template<typename U>

--- a/source/state_representation/include/state_representation/parameters/Parameter.hpp
+++ b/source/state_representation/include/state_representation/parameters/Parameter.hpp
@@ -40,6 +40,14 @@ public:
 
   /**
    * @brief Getter of the value attribute.
+   * @tparam U The expected type of the parameter
+   * @return The value attribute
+   */
+  template<typename U>
+  U get_value();
+
+  /**
+   * @brief Getter of the value attribute.
    * @return The value attribute
    */
   const T& get_value() const;
@@ -77,6 +85,12 @@ Parameter<T>& Parameter<T>::operator=(const Parameter<U>& parameter) {
   Parameter<T> temp(parameter);
   *this = temp;
   return *this;
+}
+
+template<typename T>
+template<typename U>
+U Parameter<T>::get_value() {
+  return static_cast<U>(this->value_);
 }
 
 template<typename T>

--- a/source/state_representation/test/tests/test_parameter.cpp
+++ b/source/state_representation/test/tests/test_parameter.cpp
@@ -23,11 +23,11 @@ TEST(ParameterTest, Conversion) {
 
   Parameter<CartesianPose> test1("test", CartesianPose::Random("test"));
   Parameter<CartesianState> test2(test1);
-  EXPECT_EQ(test2.get_type(), StateType::PARAMETER_CARTESIANPOSE);
+  EXPECT_EQ(test2.get_type(), StateType::PARAMETER_CARTESIANSTATE);
 
   std::shared_ptr<Parameter<CartesianState>> test3 =
       std::make_shared<Parameter<CartesianState>>(Parameter<CartesianPose>("test", CartesianPose::Random("test")));
-  EXPECT_EQ(test3->get_type(), StateType::PARAMETER_CARTESIANPOSE);
+  EXPECT_EQ(test3->get_type(), StateType::PARAMETER_CARTESIANSTATE);
 }
 
 TEST(ParameterTest, Event) {

--- a/source/state_representation/test/tests/test_parameter.cpp
+++ b/source/state_representation/test/tests/test_parameter.cpp
@@ -12,6 +12,12 @@ TEST(ParameterTest, Conversion) {
   EXPECT_EQ(int_param.get_type(), StateType::PARAMETER_INT);
   int_param.set_value(2);
   EXPECT_EQ(int_param.get_value(), 2);
+  EXPECT_EQ(typeid(int_param.get_value<double>()).name(), typeid(2.0).name());
+  Parameter<double> double_param("double");
+  EXPECT_NO_THROW(double_param = int_param);
+  EXPECT_EQ(double_param.get_type(), StateType::PARAMETER_DOUBLE);
+  EXPECT_EQ(double_param.get_name(), int_param.get_name());
+  EXPECT_EQ(double_param.get_value(), 2.0);
 
   std::vector<int> values{1, 2, 3};
   Parameter<std::vector<int>> int_array_param("test", values);


### PR DESCRIPTION
This is a little improvement that will make PR #227 a bit easier. While adding the get_value method, we figured we can do the same static cast in the copy constructor and now this ended up to be a very nice improvement because upon copy construction, the desired parameter type is actually conserved and only the name and value are copied (if the static cast doesnt fail)