### PR TITLE
Support copy module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release Versions:
 - Add static method to create Parameter pointer (#226)
 - Templated get_value method for Parameter (#228)
 - Create DS interface and DS factory classes (#227)
+- Add support for copy module in Python bindings (#232)
 
 ### Pending TODOs for the next release
 

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -19,6 +19,12 @@ void spatial_state(py::module_& m) {
   c.def("set_reference_frame", &SpatialState::set_reference_frame, "Setter of the reference frame.", "reference_frame"_a);
   c.def("is_compatible", &SpatialState::is_compatible, "Check if the state is compatible for operations with the state given as argument.", "state"_a);
 
+  c.def("__copy__", [](const SpatialState &state) {
+    return SpatialState(state);
+  });
+  c.def("__deepcopy__", [](const SpatialState &state, py::dict) {
+    return SpatialState(state);
+  }, "memo"_a);
   c.def("__repr__", [](const SpatialState& state) {
     std::stringstream buffer;
     buffer << state;
@@ -120,6 +126,12 @@ void cartesian_state(py::module_& m) {
 
   c.def("to_list", &CartesianState::to_std_vector, "Return the state as a list");
 
+  c.def("__copy__", [](const CartesianState &state) {
+    return CartesianState(state);
+  });
+  c.def("__deepcopy__", [](const CartesianState &state, py::dict) {
+    return CartesianState(state);
+  }, "memo"_a);
   c.def("__repr__", [](const CartesianState& state) {
     std::stringstream buffer;
     buffer << state;
@@ -193,6 +205,12 @@ void cartesian_pose(py::module_& m) {
   c.def("norms", &CartesianPose::norms, "Compute the norms of the state variable specified by the input type (default is full pose)", "state_variable_type"_a=CartesianStateVariable::POSE);
   c.def("normalized", &CartesianPose::normalized, "Compute the normalized pose at the state variable given in argument (default is full pose)", "state_variable_type"_a=CartesianStateVariable::POSE);
 
+  c.def("__copy__", [](const CartesianPose &pose) {
+    return CartesianPose(pose);
+  });
+  c.def("__deepcopy__", [](const CartesianPose &pose, py::dict) {
+    return CartesianPose(pose);
+  }, "memo"_a);
   c.def("__repr__", [](const CartesianPose& pose) {
     std::stringstream buffer;
     buffer << pose;
@@ -260,6 +278,12 @@ void cartesian_twist(py::module_& m) {
   c.def("norms", &CartesianTwist::norms, "Compute the norms of the state variable specified by the input type (default is full twist)", "state_variable_type"_a=CartesianStateVariable::TWIST);
   c.def("normalized", &CartesianTwist::normalized, "Compute the normalized twist at the state variable given in argument (default is full twist)", "state_variable_type"_a=CartesianStateVariable::TWIST);
 
+  c.def("__copy__", [](const CartesianTwist &twist) {
+    return CartesianTwist(twist);
+  });
+  c.def("__deepcopy__", [](const CartesianTwist &twist, py::dict) {
+    return CartesianTwist(twist);
+  }, "memo"_a);
   c.def("__repr__", [](const CartesianTwist& twist) {
     std::stringstream buffer;
     buffer << twist;
@@ -321,6 +345,12 @@ void cartesian_wrench(py::module_& m) {
   c.def("norms", &CartesianWrench::norms, "Compute the norms of the state variable specified by the input type (default is full wrench)", "state_variable_type"_a=CartesianStateVariable::WRENCH);
   c.def("normalized", &CartesianWrench::normalized, "Compute the normalized twist at the state variable given in argument (default is full wrench)", "state_variable_type"_a=CartesianStateVariable::WRENCH);
 
+  c.def("__copy__", [](const CartesianWrench &wrench) {
+    return CartesianWrench(wrench);
+  });
+  c.def("__deepcopy__", [](const CartesianWrench &wrench, py::dict) {
+    return CartesianWrench(wrench);
+  }, "memo"_a);
   c.def("__repr__", [](const CartesianWrench& wrench) {
     std::stringstream buffer;
     buffer << wrench;

--- a/python/source/state_representation/bind_jacobian.cpp
+++ b/python/source/state_representation/bind_jacobian.cpp
@@ -72,6 +72,12 @@ void bind_jacobian(py::module_& m) {
   c.def(CartesianPose() * py::self);
   c.def(Eigen::MatrixXd() * py::self);
 
+  c.def("__copy__", [](const Jacobian &jacobian) {
+    return Jacobian(jacobian);
+  });
+  c.def("__deepcopy__", [](const Jacobian &jacobian, py::dict) {
+    return Jacobian(jacobian);
+    }, "memo"_a);
   c.def("__repr__", [](const Jacobian& jacobian) {
     std::stringstream buffer;
     buffer << jacobian;

--- a/python/source/state_representation/bind_joint_space.cpp
+++ b/python/source/state_representation/bind_joint_space.cpp
@@ -94,6 +94,12 @@ void joint_state(py::module_& m) {
 
   c.def("to_list", &JointState::to_std_vector, "Return the state as a list.");
 
+  c.def("__copy__", [](const JointState &state) {
+    return JointState(state);
+  });
+  c.def("__deepcopy__", [](const JointState &state, py::dict) {
+    return JointState(state);
+  }, "memo"_a);
   c.def("__repr__", [](const JointState& state) {
     std::stringstream buffer;
     buffer << state;
@@ -154,6 +160,12 @@ void joint_positions(py::module_& m) {
   c.def("set_data", py::overload_cast<const Eigen::VectorXd&>(&JointPositions::set_data), "Set the positions data from a vector", "data"_a);
   c.def("set_data", py::overload_cast<const std::vector<double>&>(&JointPositions::set_data), "Set the positions data from a list", "data"_a);
 
+  c.def("__copy__", [](const JointPositions &positions) {
+    return JointPositions(positions);
+  });
+  c.def("__deepcopy__", [](const JointPositions &positions, py::dict) {
+    return JointPositions(positions);
+  }, "memo"_a);
   c.def("__repr__", [](const JointPositions& positions) {
     std::stringstream buffer;
     buffer << positions;
@@ -221,6 +233,12 @@ void joint_velocities(py::module_& m) {
   c.def("clamp", py::overload_cast<const Eigen::ArrayXd&, const Eigen::ArrayXd&>(&JointVelocities::clamp), "Clamp inplace the magnitude of the velocity to the values in argument", "max_absolute_value_array"_a, "noise_ratio_array"_a);
   c.def("clamped", py::overload_cast<const Eigen::ArrayXd&, const Eigen::ArrayXd&>(&JointVelocities::clamp), "Return the velocity clamped to the values in argument", "max_absolute_value_array"_a, "noise_ratio_array"_a);
 
+  c.def("__copy__", [](const JointVelocities &velocities) {
+    return JointVelocities(velocities);
+  });
+  c.def("__deepcopy__", [](const JointVelocities &velocities, py::dict) {
+    return JointVelocities(velocities);
+  }, "memo"_a);
   c.def("__repr__", [](const JointVelocities& velocities) {
     std::stringstream buffer;
     buffer << velocities;
@@ -286,6 +304,12 @@ void joint_accelerations(py::module_& m) {
   c.def("clamp", py::overload_cast<const Eigen::ArrayXd&, const Eigen::ArrayXd&>(&JointAccelerations::clamp), "Clamp inplace the magnitude of the accelerations to the values in argument", "max_absolute_value_array"_a, "noise_ratio_array"_a);
   c.def("clamped", py::overload_cast<const Eigen::ArrayXd&, const Eigen::ArrayXd&>(&JointAccelerations::clamp), "Return the accelerations clamped to the values in argument", "max_absolute_value_array"_a, "noise_ratio_array"_a);
 
+  c.def("__copy__", [](const JointAccelerations &accelerations) {
+    return JointAccelerations(accelerations);
+  });
+  c.def("__deepcopy__", [](const JointAccelerations &accelerations, py::dict) {
+    return JointAccelerations(accelerations);
+  }, "memo"_a);
   c.def("__repr__", [](const JointAccelerations& accelerations) {
     std::stringstream buffer;
     buffer << accelerations;
@@ -349,6 +373,12 @@ void joint_torques(py::module_& m) {
   c.def("clamp", py::overload_cast<const Eigen::ArrayXd&, const Eigen::ArrayXd&>(&JointTorques::clamp), "Clamp inplace the magnitude of the torque to the values in argument", "max_absolute_value_array"_a, "noise_ratio_array"_a);
   c.def("clamped", py::overload_cast<const Eigen::ArrayXd&, const Eigen::ArrayXd&>(&JointTorques::clamp), "Return the torque clamped to the values in argument", "max_absolute_value_array"_a, "noise_ratio_array"_a);
 
+  c.def("__copy__", [](const JointTorques &torques) {
+    return JointTorques(torques);
+  });
+  c.def("__deepcopy__", [](const JointTorques &torques, py::dict) {
+    return JointTorques(torques);
+  }, "memo"_a);
   c.def("__repr__", [](const JointTorques& torques) {
     std::stringstream buffer;
     buffer << torques;

--- a/python/source/state_representation/bind_parameters.cpp
+++ b/python/source/state_representation/bind_parameters.cpp
@@ -18,6 +18,12 @@ void parameter(py::module_& m) {
   c.def("get_value", &ParameterContainer::get_value, "Getter of the value attribute.");
   c.def("set_value", &ParameterContainer::set_value, "Setter of the value attribute.", py::arg("value"));
 
+  c.def("__copy__", [](const ParameterContainer &parameter) {
+    return ParameterContainer(parameter);
+  });
+  c.def("__deepcopy__", [](const ParameterContainer &parameter, py::dict) {
+    return ParameterContainer(parameter);
+  }, "memo"_a);
   c.def("__repr__", [](const ParameterContainer& parameter) {
     std::stringstream buffer;
     switch (parameter.get_type()) {

--- a/python/source/state_representation/bind_state.cpp
+++ b/python/source/state_representation/bind_state.cpp
@@ -53,6 +53,12 @@ void state(py::module_& m) {
   c.def("is_compatible", &State::is_compatible, "Check if the state is compatible for operations with the state given as argument", "state"_a);
   c.def("initialize", &State::initialize, "Initialize the State to a zero value");
 
+  c.def("__copy__", [](const State &state) {
+    return State(state);
+  });
+  c.def("__deepcopy__", [](const State &state, py::dict) {
+    return State(state);
+  }, "memo"_a);
   c.def("__repr__", [](const State& state) {
     std::stringstream buffer;
     buffer << state;

--- a/python/test/robot/test_jacobian.py
+++ b/python/test/robot/test_jacobian.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 
 import numpy as np
 from state_representation import Jacobian, CartesianPose, CartesianTwist, CartesianWrench, JointVelocities
@@ -48,6 +49,14 @@ class TestJacobian(unittest.TestCase):
         Jacobian.Random("robot", ["joint_0", "joint_1"], "ee", "robot")
         B = Jacobian.Random("robot", 7, "ee")
         B.copy()
+
+    def test_copy(self):
+        state = Jacobian.Random("robot", 7, "ee")
+        for state_copy in [copy.copy(state), copy.deepcopy(state)]:
+            self.assertEqual(state.get_frame(), state_copy.get_frame())
+            self.assertEqual(state.get_reference_frame(), state_copy.get_reference_frame())
+            self.assertListEqual(state.get_joint_names(), state_copy.get_joint_names())
+            self.assert_np_array_equal(state.data().flatten(), state_copy.data().flatten())
 
     def test_getters(self):
         jac = Jacobian("jacobian", 3, "ee", "robot")

--- a/python/test/robot/test_joint_state.py
+++ b/python/test/robot/test_joint_state.py
@@ -1,4 +1,6 @@
 import unittest
+import copy
+
 from state_representation import JointState
 
 JOINT_STATE_METHOD_EXPECTS = [
@@ -48,10 +50,20 @@ JOINT_STATE_METHOD_EXPECTS = [
 
 
 class TestJointState(unittest.TestCase):
+    def assert_np_array_equal(self, a, b):
+        self.assertListEqual(list(a), list(b))
+
     def test_callable_methods(self):
         methods = [m for m in dir(JointState) if callable(getattr(JointState, m))]
         for expected in JOINT_STATE_METHOD_EXPECTS:
             self.assertIn(expected, methods)
+
+    def test_copy(self):
+        state = JointState().Random("test", 3)
+        for state_copy in [copy.copy(state), copy.deepcopy(state)]:
+            self.assertEqual(state.get_name(), state_copy.get_name())
+            self.assertListEqual(state.get_names(), state_copy.get_names())
+            self.assert_np_array_equal(state.data(), state_copy.data())
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/space/test_cartesian_pose.py
+++ b/python/test/space/test_cartesian_pose.py
@@ -1,4 +1,6 @@
 import unittest
+import copy
+
 from state_representation import CartesianPose
 import numpy as np
 
@@ -19,6 +21,13 @@ class TestCartesianPose(unittest.TestCase):
         A = CartesianPose("A", np.array([1, 2, 3]), np.array([1, 2, 3, 4]), "B")
         self.assert_np_array_equal(A.get_position(), [1, 2, 3])
         self.assert_np_array_equal(A.get_orientation(), [1, 2, 3, 4] / np.linalg.norm([1, 2, 3, 4]))
+
+    def test_copy(self):
+        state = CartesianPose().Random("test")
+        for state_copy in [copy.copy(state), copy.deepcopy(state)]:
+            self.assertEqual(state.get_name(), state_copy.get_name())
+            self.assertEqual(state.get_reference_frame(), state_copy.get_reference_frame())
+            self.assert_np_array_equal(state.data(), state_copy.data())
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/space/test_cartesian_state.py
+++ b/python/test/space/test_cartesian_state.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -143,6 +144,11 @@ class TestCartesianState(unittest.TestCase):
         self.assertTrue(np.linalg.norm(random.get_twist()) > 0)
         self.assertTrue(np.linalg.norm(random.get_accelerations()) > 0)
         self.assertTrue(np.linalg.norm(random.get_wrench()) > 0)
+
+    def test_copy(self):
+        state = CartesianState().Random("test")
+        for state_copy in [copy.copy(state), copy.deepcopy(state)]:
+            self.assert_name_frame_data_equal(state, state_copy)
 
     def test_copy_constructor(self):
         random = CartesianState().Random("test")

--- a/python/test/space/test_spatial_state.py
+++ b/python/test/space/test_spatial_state.py
@@ -1,7 +1,7 @@
 import unittest
+import copy
 
 from state_representation import SpatialState, StateType
-
 from test.test_state import STATE_METHOD_EXPECTS
 
 SPATIAL_STATE_METHOD_EXPECTS = [
@@ -38,6 +38,14 @@ class TestState(unittest.TestCase):
         self.assertEqual(state2.get_name(), state3.get_name())
         self.assertEqual(state2.get_reference_frame(), state3.get_reference_frame())
         self.assertEqual(state2.is_empty(), state3.is_empty())
+
+    def test_copy(self):
+        state = SpatialState(StateType.CARTESIANSTATE, "test", "robot", False)
+        for state_copy in [copy.copy(state), copy.deepcopy(state)]:
+            self.assertEqual(state.get_type(), state_copy.get_type())
+            self.assertEqual(state.get_name(), state_copy.get_name())
+            self.assertEqual(state.get_reference_frame(), state_copy.get_reference_frame())
+            self.assertEqual(state.is_empty(), state_copy.is_empty())
 
     def test_compatibility(self):
         state1 = SpatialState(StateType.CARTESIANSTATE, "test", "robot", True)

--- a/python/test/test_state.py
+++ b/python/test/test_state.py
@@ -1,6 +1,7 @@
 import time
 import unittest
 import datetime
+import copy
 
 from state_representation import State, StateType
 
@@ -76,6 +77,10 @@ class TestState(unittest.TestCase):
         state.set_timestamp(datetime.datetime.now().timestamp())
         self.assertFalse(state.is_deprecated(0.1))
 
+    def test_copy(self):
+        state = State(StateType.STATE, "test", False)
+        state2 = copy.copy(state)
+        state3 = copy.deepcopy(state)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This was a quick fix that I decided to do in the background of a presentation, since I feel like I haven't contributed to control libraries in a while! Now it's possible to use the python `copy` module on the state objects.
```python
import copy
from state_representation import CartesianState

state = CartesianState.Random("A")
state_copy = copy.deepcopy(state)
```
There's a fair bit of code duplication but the alternative (making a preprocessor macro or templating it somehow) was more effort than this is worth. In any case it follows the existing pattern.

---

* Add __copy__ and __deepcopy__ methods to all state bindings to invoke the copy constructor, so that the python copy module is supported

See also:
https://pybind11.readthedocs.io/en/stable/advanced/classes.html#deepcopy-support