### PR TITLE
Add the set_parameter_value

### DIFF
--- a/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
@@ -6,8 +6,6 @@
 
 #include "dynamical_systems/exceptions/InvalidParameterException.hpp"
 #include "state_representation/parameters/Parameter.hpp"
-#include "state_representation/space/cartesian/CartesianPose.hpp"
-#include "state_representation/space/cartesian/CartesianState.hpp"
 
 /**
  * @namespace dynamical_systems
@@ -26,7 +24,7 @@ public:
   /**
    * @brief Empty constructor
    */
-  IDynamicalSystem();
+  IDynamicalSystem() = default;
 
   /**
    * @brief Check compatibility between a state and the dynamical system.
@@ -59,7 +57,7 @@ public:
    * @param name The name of the parameter
    * @return The parameter, if it exists
    */
-  std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name) const;
+  [[nodiscard]] std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name) const;
 
   /**
    * @brief Get a map of all the <name, parameter> pairs of the dynamical system.
@@ -74,7 +72,7 @@ public:
    * @return The value of the parameter, if the parameter exists
    */
   template<typename T>
-  T get_parameter_value(const std::string& name) const;
+  [[nodiscard]] T get_parameter_value(const std::string& name) const;
 
   /**
    * @brief Get a list of all the parameters of the dynamical system.
@@ -159,6 +157,11 @@ S IDynamicalSystem<S>::get_base_frame() const {
 }
 
 template<class S>
+void IDynamicalSystem<S>::set_base_frame(const S& base_frame) {
+  this->base_frame_ = base_frame;
+}
+
+template<class S>
 std::shared_ptr<state_representation::ParameterInterface> IDynamicalSystem<S>::get_parameter(const std::string& name) const {
   if (this->param_map_.find(name) == this->param_map_.cend()) {
     throw exceptions::InvalidParameterException("Could not find a parameter named '" + name + "'.");
@@ -216,5 +219,4 @@ void IDynamicalSystem<S>::set_parameter_value(const std::string& name, const T& 
   using namespace state_representation;
   this->validate_and_set_parameter(std::make_shared<Parameter<T>>(Parameter<T>(name, value)));
 }
-
 }// namespace dynamical_systems

--- a/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
@@ -59,7 +59,7 @@ public:
    * @param name The name of the parameter
    * @return The parameter, if it exists
    */
-  std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name);
+  std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name) const;
 
   /**
    * @brief Get a map of all the <name, parameter> pairs of the dynamical system.
@@ -68,13 +68,13 @@ public:
   [[nodiscard]] std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const;
 
   /**
- * @brief Get a parameter of the dynamical system by its name.
- * @tparam T Type of the parameter value
- * @param name The name of the parameter
- * @return The value of the parameter, if the parameter exists
- */
+   * @brief Get a parameter of the dynamical system by its name.
+   * @tparam T Type of the parameter value
+   * @param name The name of the parameter
+   * @return The value of the parameter, if the parameter exists
+   */
   template<typename T>
-  T get_parameter_value(const std::string& name);
+  T get_parameter_value(const std::string& name) const;
 
   /**
    * @brief Get a list of all the parameters of the dynamical system.
@@ -148,7 +148,7 @@ S IDynamicalSystem<S>::get_base_frame() const {
 }
 
 template<class S>
-std::shared_ptr<state_representation::ParameterInterface> IDynamicalSystem<S>::get_parameter(const std::string& name) {
+std::shared_ptr<state_representation::ParameterInterface> IDynamicalSystem<S>::get_parameter(const std::string& name) const {
   if (this->param_map_.find(name) == this->param_map_.cend()) {
     throw exceptions::InvalidParameterException("Could not find a parameter named '" + name + "'.");
   }
@@ -157,7 +157,7 @@ std::shared_ptr<state_representation::ParameterInterface> IDynamicalSystem<S>::g
 
 template<class S>
 template<typename T>
-T IDynamicalSystem<S>::get_parameter_value(const std::string& name) {
+T IDynamicalSystem<S>::get_parameter_value(const std::string& name) const {
   return std::static_pointer_cast<state_representation::Parameter<T>>(this->get_parameter(name))->get_value();
 }
 

--- a/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
@@ -134,10 +134,12 @@ private:
 };
 
 template<class S>
-void IDynamicalSystem<S>::assert_parameter_valid(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
+void IDynamicalSystem<S>::assert_parameter_valid(
+    const std::shared_ptr<state_representation::ParameterInterface>& parameter
+) {
   if (this->param_map_.at(parameter->get_name())->get_type() != parameter->get_type()) {
     throw dynamical_systems::exceptions::InvalidParameterException(
-        "Parameter '" + parameter->get_name() + "'exists, but has unexpected type."
+        "Parameter '" + parameter->get_name() + "' exists, but has unexpected type."
     );
   }
 }

--- a/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
@@ -101,6 +101,15 @@ public:
   void
   set_parameters(const std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>& parameters);
 
+  /**
+   * @brief Set a parameter value of the dynamical system found by its name.
+   * @tparam T Type of the parameter value
+   * @param name The name of the parameter
+   * @param value The new value of the parameter
+   */
+  template<typename T>
+  void set_parameter_value(const std::string& name, const T& value);
+
 protected:
   /**
    * @brief Compute the dynamics of the input state. Internal function,
@@ -199,6 +208,13 @@ void IDynamicalSystem<S>::set_parameters(
   for (const auto& param_it: parameters) {
     this->set_parameter(param_it.second);
   }
+}
+
+template<class S>
+template<typename T>
+void IDynamicalSystem<S>::set_parameter_value(const std::string& name, const T& value) {
+  using namespace state_representation;
+  this->validate_and_set_parameter(std::make_shared<Parameter<T>>(Parameter<T>(name, value)));
 }
 
 }// namespace dynamical_systems

--- a/source/dynamical_systems/src/IDynamicalSystem.cpp
+++ b/source/dynamical_systems/src/IDynamicalSystem.cpp
@@ -5,24 +5,17 @@
 
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/robot/JointState.hpp"
+#include "state_representation/space/cartesian/CartesianState.hpp"
 
 using namespace state_representation;
 
 namespace dynamical_systems {
-
-template<class S>
-IDynamicalSystem<S>::IDynamicalSystem() = default;
-
-template<>
-IDynamicalSystem<JointState>::IDynamicalSystem() : base_frame_(JointState()) {}
-
-template<>
-IDynamicalSystem<CartesianState>::IDynamicalSystem() : base_frame_(CartesianState()) {}
-
 template<class S>
 bool IDynamicalSystem<S>::is_compatible(const S&) const {
   throw exceptions::NotImplementedException("is_compatible(state) not implemented for this type of state.");
 }
+
+template bool IDynamicalSystem<JointState>::is_compatible(const JointState&) const;
 
 template<>
 bool IDynamicalSystem<CartesianState>::is_compatible(const CartesianState& state) const {
@@ -30,15 +23,12 @@ bool IDynamicalSystem<CartesianState>::is_compatible(const CartesianState& state
       && state.get_reference_frame() != this->get_base_frame().get_reference_frame());
 }
 
-template<>
-bool IDynamicalSystem<JointState>::is_compatible(const JointState& state) const {
-  return this->base_frame_.is_compatible(state);
-}
-
 template<class S>
 S IDynamicalSystem<S>::evaluate(const S& state) const {
   return this->compute_dynamics(state);
 }
+
+template JointState IDynamicalSystem<JointState>::evaluate(const JointState& state) const;
 
 template<>
 CartesianState IDynamicalSystem<CartesianState>::evaluate(const CartesianState& state) const {
@@ -59,24 +49,5 @@ CartesianState IDynamicalSystem<CartesianState>::evaluate(const CartesianState& 
   } else {
     return this->compute_dynamics(state);
   }
-}
-
-template<>
-JointState IDynamicalSystem<JointState>::evaluate(const JointState& state) const {
-  if (this->get_base_frame().is_empty()) {
-    throw exceptions::EmptyBaseFrameException("The base frame of the dynamical system is empty.");
-  }
-  if (!this->is_compatible(state)) {
-    throw state_representation::exceptions::IncompatibleReferenceFramesException(
-        "The evaluated state " + state.get_name() + " is incompatible with the base frame of the dynamical system "
-            + this->get_base_frame().get_name() + "."
-    );
-  }
-  return this->compute_dynamics(state);
-}
-
-template<class S>
-void IDynamicalSystem<S>::set_base_frame(const S& base_frame) {
-  this->base_frame_ = base_frame;
 }
 }// namespace dynamical_systems

--- a/source/dynamical_systems/src/PointAttractor.cpp
+++ b/source/dynamical_systems/src/PointAttractor.cpp
@@ -1,5 +1,6 @@
 #include "dynamical_systems/PointAttractor.hpp"
 
+#include "dynamical_systems/exceptions/NotImplementedException.hpp"
 #include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
 #include "dynamical_systems/exceptions/InvalidParameterException.hpp"
 #include "dynamical_systems/exceptions/IncompatibleSizeException.hpp"
@@ -57,6 +58,11 @@ void PointAttractor<S>::set_gain(const std::shared_ptr<ParameterInterface>& para
   }
 }
 
+template<class S>
+void PointAttractor<S>::set_attractor(const S&) {
+  throw exceptions::NotImplementedException("set_attractor is not implemented for this type of DS");
+}
+
 template<>
 void PointAttractor<CartesianState>::set_attractor(const CartesianState& attractor) {
   if (attractor.is_empty()) {
@@ -86,21 +92,18 @@ void PointAttractor<JointState>::set_attractor(const JointState& attractor) {
   if (attractor.is_empty()) {
     throw state_representation::exceptions::EmptyStateException(attractor.get_name() + " state is empty");
   }
-  if (this->get_base_frame().is_empty()) {
-    IDynamicalSystem<JointState>::set_base_frame(JointState::Zero(attractor.get_name(), attractor.get_names()));
-  }
-  // validate that the attractor is compatible with the DS reference name
-  if (!this->is_compatible(attractor)) {
-    throw state_representation::exceptions::IncompatibleReferenceFramesException(
-        "The attractor " + attractor.get_name() + " is incompatible with the base frame of the dynamical system "
-            + this->get_base_frame().get_name() + "."
-    );
-  }
   this->attractor_->set_value(attractor);
   if (this->gain_->get_value().size() == 0) {
     this->gain_->set_value(Eigen::MatrixXd::Identity(attractor.get_size(), attractor.get_size()));
   }
 }
+
+template<class S>
+void PointAttractor<S>::set_base_frame(const S& base_frame) {
+  this->IDynamicalSystem<S>::set_base_frame(base_frame);
+}
+
+template void PointAttractor<JointState>::set_base_frame(const JointState& base_frame);
 
 template<>
 void PointAttractor<CartesianState>::set_base_frame(const CartesianState& base_frame) {
@@ -112,21 +115,6 @@ void PointAttractor<CartesianState>::set_base_frame(const CartesianState& base_f
     // update reference frame of attractor
     auto attractor = this->attractor_->get_value();
     attractor.set_reference_frame(base_frame.get_name());
-    this->set_attractor(attractor);
-  }
-}
-
-template<>
-void PointAttractor<JointState>::set_base_frame(const JointState& base_frame) {
-  if (base_frame.is_empty()) {
-    throw state_representation::exceptions::EmptyStateException(base_frame.get_name() + " state is empty");
-  }
-  IDynamicalSystem<JointState>::set_base_frame(base_frame);
-  if (!this->attractor_->get_value().is_empty()) {
-    // update name of attractor
-    auto attractor = this->attractor_->get_value();
-    attractor.set_name(base_frame.get_name());
-    attractor.set_names(base_frame.get_names());
     this->set_attractor(attractor);
   }
 }
@@ -152,6 +140,11 @@ void PointAttractor<JointState>::validate_and_set_parameter(const std::shared_pt
   } else {
     throw exceptions::InvalidParameterException("No parameter with name '" + parameter->get_name() + "' found");
   }
+}
+
+template<class S>
+S PointAttractor<S>::compute_dynamics(const S&) const {
+  throw exceptions::NotImplementedException("compute_dynamics is not implemented for this type of DS");
 }
 
 template<>

--- a/source/dynamical_systems/test/tests/test_circular.cpp
+++ b/source/dynamical_systems/test/tests/test_circular.cpp
@@ -36,7 +36,7 @@ protected:
 };
 
 TEST_F(CircularDSTest, TestPositionOnRadius) {
-  ds->set_parameter(make_shared_parameter("limit_cycle", limit_cycle));
+  ds->set_parameter_value("limit_cycle", limit_cycle);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -52,7 +52,7 @@ TEST_F(CircularDSTest, EmptyConstructor) {
   EXPECT_TRUE(ds->get_parameter_value<Ellipsoid>("limit_cycle").get_center_pose().is_empty());
   EXPECT_TRUE(ds->get_base_frame().is_empty());
 
-  ds->set_parameter(make_shared_parameter("limit_cycle", limit_cycle));
+  ds->set_parameter_value("limit_cycle", limit_cycle);
   EXPECT_FALSE(ds->get_parameter_value<Ellipsoid>("limit_cycle").get_center_pose().is_empty());
   EXPECT_FALSE(ds->get_base_frame().is_empty());
   // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
@@ -76,7 +76,7 @@ TEST_F(CircularDSTest, EvaluateCompatibility) {
   // if no attractor is set, an exception is thrown
   EXPECT_THROW(ds->evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
 
-  ds->set_parameter(make_shared_parameter("limit_cycle", limit_cycle));
+  ds->set_parameter_value("limit_cycle", limit_cycle);
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_TRUE(ds->is_compatible(state3));
@@ -86,7 +86,7 @@ TEST_F(CircularDSTest, EvaluateCompatibility) {
 TEST_F(CircularDSTest, TestPositionOnRadiusRandomCenter) {
   limit_cycle.set_center_position(Eigen::Vector3d::Random());
   limit_cycle.set_center_orientation(Eigen::Quaterniond::UnitRandom());
-  ds->set_parameter(make_shared_parameter("limit_cycle", limit_cycle));
+  ds->set_parameter_value("limit_cycle", limit_cycle);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     state_representation::CartesianTwist twist = ds->evaluate(current_pose);
@@ -103,7 +103,7 @@ TEST_F(CircularDSTest, SetCenterAndBase) {
   auto CinA = CartesianState::Identity("C", "A");
   auto CinB = CartesianState::Identity("C", "B");
 
-  ds->set_parameter(make_shared_parameter("limit_cycle", cycle));
+  ds->set_parameter_value("limit_cycle", cycle);
   EXPECT_STREQ(ds->get_parameter_value<Ellipsoid>("limit_cycle").get_center_pose().get_name().c_str(),
                BinA.get_name().c_str());
   EXPECT_STREQ(ds->get_parameter_value<Ellipsoid>("limit_cycle").get_center_pose().get_reference_frame().c_str(),
@@ -115,9 +115,9 @@ TEST_F(CircularDSTest, SetCenterAndBase) {
 
   // setting the center is only valid if it matches the base reference frame
   cycle.set_center_state(CinA);
-  EXPECT_NO_THROW(ds->set_parameter(make_shared_parameter("limit_cycle", cycle)));
+  EXPECT_NO_THROW(ds->set_parameter_value("limit_cycle", cycle));
   Ellipsoid cycle2("C", "B");
-  EXPECT_THROW(ds->set_parameter(make_shared_parameter("limit_cycle", cycle2)),
+  EXPECT_THROW(ds->set_parameter_value("limit_cycle", cycle2),
                state_representation::exceptions::IncompatibleReferenceFramesException);
 
   // setting the base frame should also update the reference frame of the center
@@ -128,8 +128,8 @@ TEST_F(CircularDSTest, SetCenterAndBase) {
                ds->get_base_frame().get_name().c_str());
 
   // now the base frame is C, setting a center should only work if the reference frame of the center is also C
-  EXPECT_THROW(ds->set_parameter(make_shared_parameter("limit_cycle", cycle)),
+  EXPECT_THROW(ds->set_parameter_value("limit_cycle", cycle),
                state_representation::exceptions::IncompatibleReferenceFramesException);
-  EXPECT_NO_THROW(ds->set_parameter(make_shared_parameter("limit_cycle", cycle2)));
-  EXPECT_NO_THROW(ds->set_parameter(make_shared_parameter("limit_cycle", Ellipsoid("B", "C"))));
+  EXPECT_NO_THROW(ds->set_parameter_value("limit_cycle", cycle2));
+  EXPECT_NO_THROW(ds->set_parameter_value("limit_cycle", Ellipsoid("B", "C")));
 }

--- a/source/dynamical_systems/test/tests/test_factory.cpp
+++ b/source/dynamical_systems/test/tests/test_factory.cpp
@@ -3,8 +3,9 @@
 #include "dynamical_systems/DynamicalSystemFactory.hpp"
 #include "dynamical_systems/exceptions/InvalidParameterException.hpp"
 
-#include "state_representation/parameters/Parameter.hpp"
+#include "state_representation/space/cartesian/CartesianState.hpp"
 #include "state_representation/robot/JointState.hpp"
+#include "state_representation/parameters/Parameter.hpp"
 
 using namespace state_representation;
 
@@ -24,7 +25,6 @@ TEST(DSFactoryTest, CreateDS) {
   auto joint_ds = dynamical_systems::DynamicalSystemFactory<JointState>::create_dynamical_system(
       dynamical_systems::DynamicalSystemFactory<JointState>::DYNAMICAL_SYSTEM::NONE
   );
-  joint_ds->set_base_frame(JointState::Zero("robot", 3));
   ASSERT_NO_THROW(auto res = joint_ds->evaluate(JointState::Random("robot", 3)));
   EXPECT_TRUE(joint_ds->evaluate(JointState::Random("robot", 3)).is_empty());
   EXPECT_EQ(joint_ds->get_parameters().size(), 0);

--- a/source/dynamical_systems/test/tests/test_point_attractor.cpp
+++ b/source/dynamical_systems/test/tests/test_point_attractor.cpp
@@ -44,7 +44,7 @@ TEST_F(PointAttractorTest, EmptyConstructorCartesianState) {
   // base frame and attractor should be empty
   EXPECT_TRUE(ds->get_parameter_value<CartesianPose>("attractor").is_empty());
   EXPECT_TRUE(ds->get_base_frame().is_empty());
-  ds->set_parameter(make_shared_parameter("attractor", attractor));
+  ds->set_parameter_value("attractor", attractor);
   EXPECT_FALSE(ds->get_parameter_value<CartesianPose>("attractor").is_empty());
   EXPECT_FALSE(ds->get_base_frame().is_empty());
   // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
@@ -68,7 +68,7 @@ TEST_F(PointAttractorTest, EmptyIsCompatible) {
   // if no attractor is set, an exception is thrown
   EXPECT_THROW(ds->evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
 
-  ds->set_parameter(make_shared_parameter("attractor", CartesianPose::Identity("CAttractor", "A")));
+  ds->set_parameter_value("attractor", CartesianPose::Identity("CAttractor", "A"));
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_TRUE(ds->is_compatible(state3));
@@ -81,7 +81,7 @@ TEST_F(PointAttractorTest, IsCompatible) {
   CartesianState state3("C", "D");
 
   CartesianPose attractor_frame = CartesianPose::Identity("CAttractor", "A");
-  ds->set_parameter(make_shared_parameter("attractor", attractor_frame));
+  ds->set_parameter_value("attractor", attractor_frame);
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_FALSE(ds->is_compatible(state3));
@@ -97,7 +97,7 @@ TEST_F(PointAttractorTest, IsCompatible) {
 TEST_F(PointAttractorTest, PositionOnly) {
   current_pose.set_orientation(Eigen::Quaterniond::Identity());
   target_pose.set_orientation(Eigen::Quaterniond::Identity());
-  ds->set_parameter(make_shared_parameter("attractor", target_pose));
+  ds->set_parameter_value("attractor", target_pose);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -109,7 +109,7 @@ TEST_F(PointAttractorTest, PositionOnly) {
 TEST_F(PointAttractorTest, OrientationOnly) {
   current_pose.set_position(Eigen::Vector3d::Zero());
   target_pose.set_position(Eigen::Vector3d::Zero());
-  ds->set_parameter(make_shared_parameter("attractor", target_pose));
+  ds->set_parameter_value("attractor", target_pose);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -119,7 +119,7 @@ TEST_F(PointAttractorTest, OrientationOnly) {
 }
 
 TEST_F(PointAttractorTest, PositionAndOrientation) {
-  ds->set_parameter(make_shared_parameter("attractor", target_pose));
+  ds->set_parameter_value("attractor", target_pose);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -137,7 +137,7 @@ TEST_F(PointAttractorTest, FixedReferenceFrames) {
   CinA.set_pose(Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
   CinB.set_pose(Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
 
-  ds->set_parameter(make_shared_parameter("attractor", BinA));
+  ds->set_parameter_value("attractor", BinA);
 
   // evaluating a current pose B in reference frame A should give zero twist (coincident with attractor)
   CartesianTwist twist = ds->evaluate(BinA);
@@ -157,7 +157,7 @@ TEST_F(PointAttractorTest, FixedReferenceFrames) {
 
 TEST_F(PointAttractorTest, UpdateBaseReferenceFrames) {
   auto BinA = CartesianState::Random("B", "A");
-  ds->set_parameter(make_shared_parameter("attractor", BinA));
+  ds->set_parameter_value("attractor", BinA);
 
   // the base frame of the default constructed DS should be an identity frame
   // with the same name as the attractor reference frame
@@ -202,7 +202,7 @@ TEST_F(PointAttractorTest, StackedMovingReferenceFrames) {
   auto CinA = CartesianState::Identity("C", "A");
   CinA.set_pose(Eigen::Vector3d::Random(), Eigen::Quaterniond::UnitRandom());
 
-  ds->set_parameter(make_shared_parameter("attractor", BinA));
+  ds->set_parameter_value("attractor", BinA);
 
   // evaluate the twist for a fixed state C in reference frame A
   CartesianTwist twist = ds->evaluate(CinA);
@@ -238,7 +238,7 @@ TEST_F(PointAttractorTest, UpdateAttractorFrame) {
   C = CartesianState::Random("C", "robot");
   D = CartesianState::Random("D", "robot");
 
-  ds->set_parameter(make_shared_parameter("attractor", A));
+  ds->set_parameter_value("attractor", A);
 
   // state being evaluated must match the DS base frame, which is by default the attractor reference frame
   EXPECT_NO_THROW(ds->evaluate(B));
@@ -246,8 +246,8 @@ TEST_F(PointAttractorTest, UpdateAttractorFrame) {
 
   // setting the attractor to another point in the same base frame should be fine,
   // but setting it with a different base frame should give an error
-  EXPECT_NO_THROW(ds->set_parameter(make_shared_parameter("attractor", B)));
-  EXPECT_THROW(ds->set_parameter(make_shared_parameter("attractor", C)),
+  EXPECT_NO_THROW(ds->set_parameter_value("attractor", B));
+  EXPECT_THROW(ds->set_parameter_value("attractor", C),
                state_representation::exceptions::IncompatibleReferenceFramesException);
 
   // after updating the base frame, the attractor reference frame should also be updated
@@ -256,9 +256,9 @@ TEST_F(PointAttractorTest, UpdateAttractorFrame) {
                C.get_reference_frame().c_str());
 
   // with the new base frame, setting the attractor should succeed / fail accordingly
-  EXPECT_THROW(ds->set_parameter(make_shared_parameter("attractor", B)),
+  EXPECT_THROW(ds->set_parameter_value("attractor", B),
                state_representation::exceptions::IncompatibleReferenceFramesException);
-  EXPECT_NO_THROW(ds->set_parameter(make_shared_parameter("attractor", C)));
+  EXPECT_NO_THROW(ds->set_parameter_value("attractor", C));
 
   // now the evaluation should also succeed when matching the updated base frame
   EXPECT_THROW(ds->evaluate(B), state_representation::exceptions::IncompatibleReferenceFramesException);

--- a/source/dynamical_systems/test/tests/test_point_attractor.cpp
+++ b/source/dynamical_systems/test/tests/test_point_attractor.cpp
@@ -4,10 +4,12 @@
 #include "dynamical_systems/exceptions/EmptyBaseFrameException.hpp"
 #include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
 
+#include "state_representation/space/cartesian/CartesianState.hpp"
+#include "state_representation/space/cartesian/CartesianPose.hpp"
+#include "state_representation/parameters/Parameter.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
-#include "state_representation/parameters/Parameter.hpp"
-#include "state_representation/space/cartesian/CartesianPose.hpp"
+
 
 using namespace state_representation;
 using namespace dynamical_systems;

--- a/source/dynamical_systems/test/tests/test_ring.cpp
+++ b/source/dynamical_systems/test/tests/test_ring.cpp
@@ -4,6 +4,8 @@
 #include "dynamical_systems/exceptions/EmptyBaseFrameException.hpp"
 #include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
 
+#include "state_representation/space/cartesian/CartesianState.hpp"
+#include "state_representation/space/cartesian/CartesianPose.hpp"
 #include "state_representation/parameters/Parameter.hpp"
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"

--- a/source/dynamical_systems/test/tests/test_ring.cpp
+++ b/source/dynamical_systems/test/tests/test_ring.cpp
@@ -39,7 +39,7 @@ TEST_F(RingDSTest, EmptyConstructor) {
   CartesianPose center = CartesianPose::Identity("CAttractor", "A");
   // base frame and attractor should be empty
   EXPECT_TRUE(ds->get_parameter_value<CartesianPose>("center").is_empty());
-  ds->set_parameter(make_shared_parameter("center", center));
+  ds->set_parameter_value("center", center);
   EXPECT_FALSE(ds->get_parameter_value<CartesianPose>("center").is_empty());
   EXPECT_FALSE(ds->get_base_frame().is_empty());
   // when attractor was set without a base frame, expect base frame to be identity with name / reference_frame of attractor
@@ -64,7 +64,7 @@ TEST_F(RingDSTest, EvaluateComptability) {
   // if no attractor is set, an exception is thrown
   EXPECT_THROW(ds->evaluate(state4), dynamical_systems::exceptions::EmptyAttractorException);
 
-  ds->set_parameter(make_shared_parameter("center", center));
+  ds->set_parameter_value("center", center);
   EXPECT_TRUE(ds->is_compatible(state1));
   EXPECT_FALSE(ds->is_compatible(state2));
   EXPECT_TRUE(ds->is_compatible(state3));
@@ -72,10 +72,10 @@ TEST_F(RingDSTest, EvaluateComptability) {
 }
 
 TEST_F(RingDSTest, PointsOnRadius) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", radius));
-  ds->set_parameter(make_shared_parameter<double>("width", width));
-  ds->set_parameter(make_shared_parameter<double>("speed", speed));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", radius);
+  ds->set_parameter_value("width", width);
+  ds->set_parameter_value("speed", speed);
   CartesianTwist twist;
 
   // zero output at center
@@ -109,11 +109,11 @@ TEST_F(RingDSTest, PointsOnRadius) {
 }
 
 TEST_F(RingDSTest, PointsNearRadius) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", radius));
-  ds->set_parameter(make_shared_parameter<double>("width", width));
-  ds->set_parameter(make_shared_parameter<double>("speed", speed));
-  ds->set_parameter(make_shared_parameter<double>("field_strength", field_strength));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", radius);
+  ds->set_parameter_value("width", width);
+  ds->set_parameter_value("speed", speed);
+  ds->set_parameter_value("field_strength", field_strength);
   CartesianTwist twist;
 
   current_pose.set_position(radius + width, 0, 0);
@@ -143,11 +143,11 @@ TEST_F(RingDSTest, PointsNearRadius) {
 }
 
 TEST_F(RingDSTest, BehaviourNearBoundaryAtHighSpeeds) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", 1.0));
-  ds->set_parameter(make_shared_parameter<double>("width", 0.1));
-  ds->set_parameter(make_shared_parameter<double>("speed", 10.0));
-  ds->set_parameter(make_shared_parameter<double>("field_strength", 2.0));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", 1.0);
+  ds->set_parameter_value("width", 0.1);
+  ds->set_parameter_value("speed", 10.0);
+  ds->set_parameter_value("field_strength", 2.0);
   CartesianTwist twist;
 
   current_pose.set_position(0, radius + 1.001 * width, 0);
@@ -162,8 +162,8 @@ TEST_F(RingDSTest, BehaviourNearBoundaryAtHighSpeeds) {
 }
 
 TEST_F(RingDSTest, ConvergenceOnRadius) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", radius));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", radius);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -177,8 +177,8 @@ TEST_F(RingDSTest, ConvergenceOnRadius) {
 TEST_F(RingDSTest, ConvergenceOnRadiusRandomCenter) {
   center.set_position(Eigen::Vector3d::Random());
   center.set_orientation(Eigen::Quaterniond::UnitRandom());
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", radius));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", radius);
 
   for (unsigned int i = 0; i < nb_steps; ++i) {
     CartesianTwist twist = ds->evaluate(current_pose);
@@ -190,8 +190,8 @@ TEST_F(RingDSTest, ConvergenceOnRadiusRandomCenter) {
 }
 
 TEST_F(RingDSTest, ZeroNormalGain) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("normal_gain", 0.0));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("normal_gain", 0.0);
 
   double startingHeight = current_pose.get_position().z();
   for (unsigned int i = 0; i < nb_steps; ++i) {
@@ -203,10 +203,10 @@ TEST_F(RingDSTest, ZeroNormalGain) {
 }
 
 TEST_F(RingDSTest, OrientationAroundCircle) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", radius));
-  ds->set_parameter(make_shared_parameter<double>("width", width));
-  ds->set_parameter(make_shared_parameter<double>("speed", 0.0));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", radius);
+  ds->set_parameter_value("width", width);
+  ds->set_parameter_value("speed", 0.0);
   CartesianTwist twist;
 
   // at the position {radius, 0, 0}, the orientation attractor is by default null,
@@ -236,10 +236,10 @@ TEST_F(RingDSTest, OrientationAroundCircle) {
 }
 
 TEST_F(RingDSTest, OrientationRestitutionAtZeroAngle) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", radius));
-  ds->set_parameter(make_shared_parameter<double>("width", width));
-  ds->set_parameter(make_shared_parameter<double>("speed", 0.0));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", radius);
+  ds->set_parameter_value("width", width);
+  ds->set_parameter_value("speed", 0.0);
   CartesianTwist twist;
 
   // at the position {radius, 0, 0}, the orientation attractor is by default null (angle around circle is 0)
@@ -268,10 +268,10 @@ TEST_F(RingDSTest, OrientationRestitutionAtZeroAngle) {
 }
 
 TEST_F(RingDSTest, OrientationRotationOffset) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
-  ds->set_parameter(make_shared_parameter<double>("radius", radius));
-  ds->set_parameter(make_shared_parameter<double>("width", width));
-  ds->set_parameter(make_shared_parameter<double>("speed", 0.0));
+  ds->set_parameter_value("center", center);
+  ds->set_parameter_value("radius", radius);
+  ds->set_parameter_value("width", width);
+  ds->set_parameter_value("speed", 0.0);
   CartesianTwist twist;
 
   current_pose.set_position(radius, 0, 0);
@@ -281,7 +281,7 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // if the rotation offset is the same as the current orientation, the angular velocity at
   // position {radius, 0, 0} is always zero
   current_pose.set_orientation(rotation);
-  ds->set_parameter(make_shared_parameter("rotation_offset", current_pose));
+  ds->set_parameter_value("rotation_offset", current_pose);
   twist = ds->evaluate(current_pose);
   EXPECT_NEAR(twist.get_angular_velocity().norm(), 0, tol);
 
@@ -298,17 +298,17 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
   // rotate the center plane in the base frame, and set the current position to have the same relative
   // offset that gives a zero command (no rotation offset)
   center.set_orientation(Eigen::Quaterniond::UnitRandom());
-  ds->set_parameter(make_shared_parameter("center", center));
+  ds->set_parameter_value("center", center);
   current_pose = CartesianPose("B", Eigen::Vector3d(radius, 0, 0), "A");
   current_pose = center * current_pose;
-  ds->set_parameter(make_shared_parameter("rotation_offset", CartesianPose::Identity("offset")));
+  ds->set_parameter_value("rotation_offset", CartesianPose::Identity("offset"));
   twist = ds->evaluate(current_pose);
   EXPECT_NEAR(twist.get_angular_velocity().norm(), 0, tol);
 
   // for any rotation offset in a rotated center plane, the output will
   // still be zero if the current position and orientation matches the rotation offset
   rotation = Eigen::Quaterniond::UnitRandom();
-  ds->set_parameter(make_shared_parameter("rotation_offset", CartesianPose("offset", rotation)));
+  ds->set_parameter_value("rotation_offset", CartesianPose("offset", rotation));
   current_pose = CartesianPose(
       "B", Eigen::Vector3d(radius, 0, 0), ds->get_parameter_value<CartesianPose>("rotation_offset").get_orientation(),
       "A"
@@ -334,8 +334,8 @@ TEST_F(RingDSTest, OrientationRotationOffset) {
 }
 
 TEST_F(RingDSTest, BaseFrameBehaviours) {
-  auto AinB = CartesianState::Random("A", "B");
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", AinB));
+  auto AinB = CartesianPose::Random("A", "B");
+  ds->set_parameter_value("center", AinB);
 
   // setting the center through the constructor should also set the base frame (as Identity frame)
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_name().c_str(), "A");
@@ -345,8 +345,8 @@ TEST_F(RingDSTest, BaseFrameBehaviours) {
   EXPECT_NEAR(ds->get_base_frame().get_pose().norm(), 1, tol);
 
   // setting the center should fail if it is incompatible with the base frame
-  auto CinD = CartesianState::Random("C", "D");
-  EXPECT_THROW(ds->set_parameter(make_shared_parameter("center", CartesianPose(CinD))),
+  auto CinD = CartesianPose::Random("C", "D");
+  EXPECT_THROW(ds->set_parameter_value("center", CartesianPose(CinD)),
                state_representation::exceptions::IncompatibleReferenceFramesException);
 
   // updating the base frame should "move" the center frame but not change its magnitude
@@ -360,50 +360,50 @@ TEST_F(RingDSTest, BaseFrameBehaviours) {
   EXPECT_NEAR(ds->get_parameter_value<CartesianPose>("center").get_pose().norm(), centerNorm, tol);
 
   // setting the center should succeed if it is expressed relative to the base frame
-  auto BinC = CartesianState::Random("B", "C");
-  EXPECT_NO_THROW(ds->set_parameter(make_shared_parameter("center", CartesianPose(BinC))));
+  auto BinC = CartesianPose::Random("B", "C");
+  EXPECT_NO_THROW(ds->set_parameter_value("center", BinC));
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_name().c_str(), "B");
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_reference_frame().c_str(), "C");
 
   // setting the center should also succeed if it shares the same reference frame as the base frame
-  auto BinD = CartesianState::Random("B", "D");
-  EXPECT_NO_THROW(ds->set_parameter(make_shared_parameter("center", CartesianPose(BinD))));
+  auto BinD = CartesianPose::Random("B", "D");
+  EXPECT_NO_THROW(ds->set_parameter_value("center", BinD));
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_name().c_str(), "B");
   // the reference frame is still C, not D, because the center is internally represented relative to the base frame (C)
   EXPECT_STREQ(ds->get_parameter_value<CartesianPose>("center").get_reference_frame().c_str(), "C");
 }
 
 TEST_F(RingDSTest, SettersAndGetters) {
-  ds->set_parameter(make_shared_parameter<CartesianPose>("center", center));
+  ds->set_parameter_value("center", center);
 
   auto pose = CartesianState::Random("C");
-  ds->set_parameter(make_shared_parameter("center", CartesianPose(pose)));
+  ds->set_parameter_value("center", CartesianPose(pose));
   auto pose2 = ds->get_parameter_value<CartesianPose>("center");
   EXPECT_STREQ(pose.get_name().c_str(), pose2.get_name().c_str());
   EXPECT_STREQ(pose.get_reference_frame().c_str(), pose2.get_reference_frame().c_str());
   EXPECT_NEAR(pose.get_pose().norm(), pose2.get_pose().norm(), tol);
 
   // all other setters should store the value
-  ds->set_parameter(
-      make_shared_parameter("rotation_offset", CartesianPose("offset", Eigen::Quaterniond(1, 2, 3, 4).normalized())));
+  ds->set_parameter_value(
+      "rotation_offset", CartesianPose("offset", Eigen::Quaterniond(1, 2, 3, 4).normalized()));
   EXPECT_NEAR(ds->get_parameter_value<CartesianPose>("rotation_offset").get_orientation().angularDistance(
       Eigen::Quaterniond(1, 2, 3, 4).normalized()), 0, tol);
 
-  ds->set_parameter(make_shared_parameter("radius", 1.0));
+  ds->set_parameter_value("radius", 1.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("radius"), 1.0, tol);
 
-  ds->set_parameter(make_shared_parameter("width", 2.0));
+  ds->set_parameter_value("width", 2.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("width"), 2.0, tol);
 
-  ds->set_parameter(make_shared_parameter("speed", 3.0));
+  ds->set_parameter_value("speed", 3.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("speed"), 3.0, tol);
 
-  ds->set_parameter(make_shared_parameter("field_strength", 4.0));
+  ds->set_parameter_value("field_strength", 4.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("field_strength"), 4.0, tol);
 
-  ds->set_parameter(make_shared_parameter("normal_gain", 5.0));
+  ds->set_parameter_value("normal_gain", 5.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("normal_gain"), 5.0, tol);
 
-  ds->set_parameter(make_shared_parameter("angular_gain", 6.0));
+  ds->set_parameter_value("angular_gain", 6.0);
   EXPECT_NEAR(ds->get_parameter_value<double>("angular_gain"), 6.0, tol);
 }


### PR DESCRIPTION
The `set_parameter_value` function was not implemented forcing to use `set_parameter(std::make_shared<...>)` syntax which is very verbose and not friendly to use at all. It is also misleading because  you would think that it would reset the underlying pointer to set it as the newly provided (expected behavior).

This is not what is happening in the background as the nested implementation of the `set_parameter` function at the end just copy the value of the new pointer into the old pointer. This would be the expected behavior of the `set_parameter_value` but not a `set_parameter` function in which you throw a pointer.

Unfortunately, I haven't found yet a proper way to write those functions with their correct expected behavior. For now, I have moved the `set_parameter(std::make_shared<...>)` syntax in the `set_parameter_value` function which, at least, lighten a bit the syntax of setting new values for parameters.

I have also made a few corrections with missing `const` and `[[nodiscard]]` keywords. One of the biggest refactor concerns the `JointState` implementation. It does not make sense to provide a `base_frame` for it which should be only needed for Spatial DS. I have, therefore, updated the template implementations to remove this need.