### PR TITLE
Avoid exception with the default DS in evaluate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release Versions:
 - Add support for copy module in Python bindings (#232)
 - Refactor dynamical systems using factory pattern (#233)
 - Propagate DS refactor to demos (#234)
+- Avoid exception with the default DS in evaluate (#237)
 
 ### Pending TODOs for the next release
 

--- a/source/dynamical_systems/src/IDynamicalSystem.cpp
+++ b/source/dynamical_systems/src/IDynamicalSystem.cpp
@@ -55,11 +55,7 @@ CartesianState IDynamicalSystem<CartesianState>::evaluate(const CartesianState& 
     }
     CartesianState result = this->get_base_frame().inverse() * state;
     result = this->compute_dynamics(result);
-    if (result.is_empty()) {
-      return result;
-    } else {
-      return this->get_base_frame() * result;
-    }
+    return result.is_empty() ? result : this->get_base_frame() * result;
   } else {
     return this->compute_dynamics(state);
   }

--- a/source/dynamical_systems/src/IDynamicalSystem.cpp
+++ b/source/dynamical_systems/src/IDynamicalSystem.cpp
@@ -55,7 +55,11 @@ CartesianState IDynamicalSystem<CartesianState>::evaluate(const CartesianState& 
     }
     CartesianState result = this->get_base_frame().inverse() * state;
     result = this->compute_dynamics(result);
-    return this->get_base_frame() * result;
+    if (result.is_empty()) {
+      return result;
+    } else {
+      return this->get_base_frame() * result;
+    }
   } else {
     return this->compute_dynamics(state);
   }


### PR DESCRIPTION
This is something I detected while I was doing the bindings for the DS. The DefaultDynamicalSystem returns an empty state in `compute_dynamics` and depending on the input state that was given to `evaluate`, the DS will try to transform this empty state back into the original frame of reference. This would obviously fail because the multiplication with an empty state throws an error. This change avoids this situation.