### PR TITLE
Return a state that has same name as input in PointAttractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Release Versions:
   and override `is_compatible` for PointAttractor DS (#236, #239)
 - Add python bindings for dynamical_systems module (#238)
 - Install Eigen manually, version 3.4 (#240)
+- Return a state that has same name as input in PointAttractor (#241)
 
 ### Pending TODOs for the next release
 

--- a/source/dynamical_systems/src/PointAttractor.cpp
+++ b/source/dynamical_systems/src/PointAttractor.cpp
@@ -176,13 +176,13 @@ CartesianState PointAttractor<CartesianState>::compute_dynamics(const CartesianS
   }
   CartesianTwist twist = CartesianPose(this->attractor_->get_value()) - CartesianPose(state);
   twist *= this->gain_->get_value();
-  return twist;
+  return CartesianTwist(state.get_name(), twist.get_twist(), this->attractor_->get_value().get_reference_frame());
 }
 
 template<>
 JointState PointAttractor<JointState>::compute_dynamics(const JointState& state) const {
   JointVelocities velocities = JointPositions(this->attractor_->get_value()) - JointPositions(state);
   velocities *= this->gain_->get_value();
-  return velocities;
+  return JointVelocities(state.get_name(), this->attractor_->get_value().get_names(), velocities.get_velocities());
 }
 }// namespace dynamical_systems


### PR DESCRIPTION
As @buschbapti found out while updating modulo, the PointAttractor DS returns a state that does not have the same name as the input state. This should not be the case, and is not the case for all the other DSs. This PR fixes this problem