### PR TITLE
Add the remote user configuration in base Dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Step 2: If not already done, [create a remote toolchain in CLion](https://www.je
 using the following credentials:
  - Host: `127.0.0.1`
  - Port: `2222` (or custom specified port)
- - User name: `remote`
+ - User name: `developer`
  - Authentication type: `Key pair`
  
 Step 3: If not already done, [create a CMake profile that uses the remote toolchain](https://www.jetbrains.com/help/clion/remote-projects-support.html#CMakeProfile).

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS core-build-dependencies
+FROM ubuntu:20.04 as core-build-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 # install core compilation and access dependencies for building the libraries
@@ -88,7 +88,7 @@ RUN ( \
   ) > /etc/ssh/sshd_config_development \
   && mkdir /run/sshd
 
-ENV USER remote
+ENV USER developer
 ENV HOME /home/${USER}
 
 # create amd configure a new user
@@ -102,8 +102,8 @@ RUN chmod 0440 /etc/sudoers.d/99_aptget && chown root:root /etc/sudoers.d/99_apt
 
 # Configure sshd entrypoint to authorise the new user for ssh access and
 # optionally update UID and GID when invoking the container with the entrypoint script
-#COPY ./config/sshd_entrypoint.sh /sshd_entrypoint.sh
-#RUN chmod 744 /sshd_entrypoint.sh
+COPY ./docker/sshd_entrypoint.sh /sshd_entrypoint.sh
+RUN chmod 744 /sshd_entrypoint.sh
 
 # create the credentials to be able to pull private repos using ssh
 RUN mkdir /root/.ssh/ && ssh-keyscan github.com | tee -a /root/.ssh/known_hosts

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -71,8 +71,6 @@ RUN rm -rf /tmp/*
 
 FROM project-dependencies as ssh-configuration
 
-RUN echo "Set disable_coredump false" >> /etc/sudo.conf
-
 RUN apt-get update && apt-get install -y \
     sudo \
     libssl-dev \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -69,19 +69,58 @@ WORKDIR /home
 RUN rm -rf /tmp/*
 
 
-FROM project-dependencies as development-dependencies
+FROM project-dependencies as ssh-configuration
+
+RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+
+RUN apt-get update && apt-get install -y \
+    sudo \
+    libssl-dev \
+    ssh \
+    iputils-ping \
+    rsync \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure sshd server settings
+RUN ( \
+    echo 'LogLevel DEBUG2'; \
+    echo 'PubkeyAuthentication yes'; \
+    echo 'Subsystem sftp /usr/lib/openssh/sftp-server'; \
+  ) > /etc/ssh/sshd_config_development \
+  && mkdir /run/sshd
+
+ENV USER remote
+ENV HOME /home/${USER}
+
+# create amd configure a new user
+ARG UID=1000
+ARG GID=1000
+RUN addgroup --gid ${GID} ${USER}
+RUN adduser --gecos "Remote User" --uid ${UID} --gid ${GID} ${USER} && yes | passwd ${USER}
+RUN usermod -a -G dialout ${USER}
+RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/99_aptget
+RUN chmod 0440 /etc/sudoers.d/99_aptget && chown root:root /etc/sudoers.d/99_aptget
+
+# Configure sshd entrypoint to authorise the new user for ssh access and
+# optionally update UID and GID when invoking the container with the entrypoint script
+#COPY ./config/sshd_entrypoint.sh /sshd_entrypoint.sh
+#RUN chmod 744 /sshd_entrypoint.sh
+
+# create the credentials to be able to pull private repos using ssh
+RUN mkdir /root/.ssh/ && ssh-keyscan github.com | tee -a /root/.ssh/known_hosts
+
+RUN echo "session required pam_limits.so" | tee --append /etc/pam.d/common-session > /dev/null
+
+
+FROM ssh-configuration as development-dependencies
 
 RUN apt-get update && apt-get install -y \
     clang \
-    iputils-ping \
     gdb \
-    libssl-dev \
     python \
     python3-dev \
     python3-pip \
-    rsync \
-    ssh \
-    sudo \
     tar \
     unzip \
     && apt-get clean \

--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS build-stage
+FROM ubuntu:20.04 as build-stage
 ARG PROTOBUF_VERSION=3.17.0
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -25,7 +25,7 @@ RUN ./autogen.sh \
     && make \
     && make install
 
-FROM ubuntu:20.04 AS google-dependencies
+FROM ubuntu:20.04 as google-dependencies
 COPY --from=build-stage /usr/local/include/google /usr/local/include/google
 COPY --from=build-stage /usr/local/lib/libproto* /usr/local/lib/
 COPY --from=build-stage /usr/local/bin/protoc /usr/local/bin

--- a/demos/control_loop_examples/Dockerfile
+++ b/demos/control_loop_examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM control-libraries/source-dependencies as runtime-demonstrations
+FROM epfl-lasa/control-libraries/install
 
 WORKDIR /tmp/
 COPY . ./control_loop_examples
@@ -8,3 +8,5 @@ RUN cmake .. && make -j all && make install
 
 WORKDIR /usr/local/bin
 RUN rm -rf /tmp/demos/
+
+USER developer

--- a/demos/control_loop_examples/run-demo.sh
+++ b/demos/control_loop_examples/run-demo.sh
@@ -1,36 +1,45 @@
 #!/usr/bin/env bash
-# Build a docker image to compile the library and run tests
-MULTISTAGE_TARGET="runtime-demonstrations"
 
-REBUILD=0
-while getopts 'r' opt; do
-    case $opt in
-        r) REBUILD=1 ;;
-        *) echo 'Error in command line parsing' >&2
-           exit 1
-    esac
+IMAGE_NAME=epfl-lasa/control-libraries/control-loop-examples
+IMAGE_TAG=latest
+
+HELP_MESSAGE="Usage: run-demo.sh [-s <script>] [-r] [-v]
+Options:
+  -s, --script                    If provided, the desired script that should be
+                                  executed when starting the container.
+  -r, --rebuild                   Rebuild the image using the docker
+                                  --no-cache option.
+  -v, --verbose                   Use the verbose option during the building
+                                  process.
+  -h, --help                      Show this help message.
+"
+
+BUILD_FLAGS=()
+TARGET_SCRIPT=""
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  case $opt in
+    -s|--script) TARGET_SCRIPT="$2"; shift;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain); shift ;;
+    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
+    *) echo 'Error in command line parsing' >&2
+       echo -e "\n${HELP_MESSAGE}"
+       exit 1
+  esac
 done
-shift "$(( OPTIND - 1 ))"
 
-NAME=$(echo "${PWD##*/}" | tr _ -)/$MULTISTAGE_TARGET
-TAG="latest"
-TARGET_SCRIPT=${1}
 
-BUILD_FLAGS=(--target "${MULTISTAGE_TARGET}")
-BUILD_FLAGS+=(-t "${NAME}:${TAG}")
-
-if [ "$REBUILD" -eq 1 ]; then
-    BUILD_FLAGS+=(--no-cache)
-fi
-
-MULTISTAGE_SOURCE_TARGET="source-dependencies"
-DOCKER_BUILDKIT=1 docker build --target "${MULTISTAGE_SOURCE_TARGET}" \
-  -t "control-libraries/${MULTISTAGE_SOURCE_TARGET}" \
+docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies
+DOCKER_BUILDKIT=1 docker build --target "install" \
+  -t "epfl-lasa/control-libraries/install" \
+  --build-arg "BUILD_TESTING=OFF" \
+  "${BUILD_FLAGS[@]}" \
   -f ../../source/Dockerfile.source ../../source || exit
-DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" . || exit
+DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" . -t "${IMAGE_NAME}:${IMAGE_TAG}" || exit
 
-if [ -z "${1}" ]; then
-  docker run -it --rm "${NAME}:${TAG}"
+if [ -z "${TARGET_SCRIPT}" ]; then
+  docker run -it --rm "${IMAGE_NAME}:${IMAGE_TAG}"
 else
-  docker run --rm "${NAME}:${TAG}" "./${1}"
+  docker run --rm "${IMAGE_NAME}:${IMAGE_TAG}" "./${TARGET_SCRIPT}"
 fi

--- a/demos/ros2_examples/Dockerfile
+++ b/demos/ros2_examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM control-libraries/source-dependencies as ros-dependencies
+FROM epfl-lasa/control-libraries/install as ros-dependencies
 
 # install ROS
 ENV ROS_DISTRO="foxy"
@@ -14,19 +14,8 @@ RUN apt update && apt install -y ros-${ROS_DISTRO}-ros-base \
     sudo \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# create a user with same permissions as the host itself
-ENV USER ros2
-ARG UID=1000
-ARG GID=1000
-RUN addgroup --gid ${GID} ${USER}
-RUN adduser --gecos "ROS2 User" --disabled-password --uid ${UID} --gid ${GID} ${USER}
-RUN usermod -a -G dialout ${USER}
-RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers.d/99_aptget > /dev/null \
-    && chmod 0440 /etc/sudoers.d/99_aptget \
-    && chown root:root /etc/sudoers.d/99_aptget
-
 # change user to the newly created one
-USER ${USER}
+USER developer
 ENV HOME /home/${USER}
 
 # add and build a ros workspace

--- a/demos/ros2_examples/README.md
+++ b/demos/ros2_examples/README.md
@@ -19,7 +19,7 @@ Running the scripts uses ROS2 commands, e.g. to run the `task_space_control_loop
 ros2 run ros2_examples task_space_control_loop
 ```
 
-You can also directly use the launchfile that starts any requirement for the demo to run correctly:
+You can also directly use the launch file that starts any requirement for the demo to run correctly:
 
 ```console
 ros2 launch ros2_examples task_space_control_loop.py

--- a/demos/ros2_examples/run-demo.sh
+++ b/demos/ros2_examples/run-demo.sh
@@ -1,74 +1,67 @@
 #!/usr/bin/env bash
-# change to false if not using nvidia graphic cards
-USE_NVIDIA_TOOLKIT=false
-# change to  false to use host network
-ISISOLATED=true
 
-# Build a docker image to compile the library and run tests
 MULTISTAGE_TARGET="runtime-demonstrations"
+IMAGE_NAME=epfl-lasa/control-libraries/ros2-examples
+IMAGE_TAG="${MULTISTAGE_TARGET}"
+GPUS=""
+GENERATE_HOST_NAME=true
 
-NETWORK=host
-if [ "${ISISOLATED}" = true ]; then
-    docker network inspect isolated >/dev/null 2>&1 || docker network create --driver bridge isolated
-    NETWORK=isolated
-fi
+HELP_MESSAGE="Usage: run-demo.sh [-r] [-v]
+Options:
+  --gpus <gpu_options>            Add GPU access for applications that
+                                  require hardware acceleration (e.g. Gazebo)
+                                  For the list of gpu_options parameters see:
+      >>> https://docs.docker.com/config/containers/resource_constraints
+  -r, --rebuild                   Rebuild the image using the docker
+                                  --no-cache option.
+  -v, --verbose                   Use the verbose option during the building
+                                  process.
+  -h, --help                      Show this help message.
+"
 
-REBUILD=0
-while getopts 'r' opt; do
-    case $opt in
-        r) REBUILD=1 ;;
-        *) echo 'Error in command line parsing' >&2
-           exit 1
-    esac
+BUILD_FLAGS=()
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  case $opt in
+    --gpus) GPUS=$2; shift 1;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain); shift ;;
+    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
+    *) echo 'Error in command line parsing' >&2
+       echo -e "\n${HELP_MESSAGE}"
+       exit 1
+  esac
 done
-shift "$(( OPTIND - 1 ))"
 
-PACKAGE_NAME=$(echo "${PWD##*/}" | tr _ -)
-IMAGE_NAME="${PACKAGE_NAME}/$MULTISTAGE_TARGET"
-TAG="latest"
-
-BUILD_FLAGS=(--target "${MULTISTAGE_TARGET}")
-
-if [[ "$OSTYPE" != "darwin"* ]]; then
-  UID="$(id -u "${USER}")"
-  GID="$(id -g "${USER}")"
-  BUILD_FLAGS+=(--build-arg UID="${UID}")
-  BUILD_FLAGS+=(--build-arg GID="${GID}")
-fi
-
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${TAG}")
-
-if [ "$REBUILD" -eq 1 ]; then
-    BUILD_FLAGS+=(--no-cache)
-fi
-
-MULTISTAGE_SOURCE_TARGET="source-dependencies"
-DOCKER_BUILDKIT=1 docker build --target "${MULTISTAGE_SOURCE_TARGET}" \
-  -t "control-libraries/${MULTISTAGE_SOURCE_TARGET}" \
+docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies
+DOCKER_BUILDKIT=1 docker build --target "install" \
+  -t "epfl-lasa/control-libraries/install" \
+  --build-arg "BUILD_TESTING=OFF" \
+  "${BUILD_FLAGS[@]}" \
   -f ../../source/Dockerfile.source ../../source || exit
-DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" . || exit
 
-#create a shared volume to store rviz config files
-mkdir -p "rviz"
-docker volume create --driver local \
-    --opt type="none" \
-    --opt device="${PWD}/rviz/" \
-    --opt o="bind" \
-    "${PACKAGE_NAME}_rviz_vol"
+DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" . --target "${MULTISTAGE_TARGET}" -t "${IMAGE_NAME}:${IMAGE_TAG}" || exit
 
-[[ ${USE_NVIDIA_TOOLKIT} = true ]] && GPU_FLAG="--gpus all" || GPU_FLAG=""
+RUN_FLAGS=(-u developer)
+if [ -n "${GPUS}" ]; then
+  RUN_FLAGS+=(--gpus "${GPUS}")
+  RUN_FLAGS+=(--env DISPLAY="${DISPLAY}")
+  RUN_FLAGS+=(--env NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES:-all}")
+  RUN_FLAGS+=(--env NVIDIA_DRIVER_CAPABILITIES="${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics")
+fi
 
-xhost +
-docker run \
-  ${GPU_FLAG} \
-  --privileged \
-  -it \
-  --rm \
-  --net="${NETWORK}" \
-  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-  --volume="$XAUTH:$XAUTH" \
-  --volume="${PACKAGE_NAME}_rviz_vol:/home/ros2/ros2_ws/install/ros2_examples/share/ros2_examples/rviz/:rw" \
-  --env XAUTHORITY="$XAUTH" \
-  --env DISPLAY="${DISPLAY}" \
-  "${IMAGE_NAME}:${TAG}"
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+  RUN_FLAGS+=(-e DISPLAY=host.docker.internal:0)
+else
+  xhost +
+  RUN_FLAGS+=(-e DISPLAY="${DISPLAY}")
+  RUN_FLAGS+=(-e XAUTHORITY="${XAUTHORITY}")
+  RUN_FLAGS+=(-v /tmp/.X11-unix:/tmp/.X11-unix:rw)
+  RUN_FLAGS+=(--device=/dev/dri:/dev/dri)
+fi
 
+docker run -it --rm \
+  "${RUN_FLAGS[@]}" \
+  --volume="$(pwd)/rviz:/home/ros2/ros2_ws/install/ros2_examples/share/ros2_examples/rviz/:rw" \
+  --name "${CONTAINER_NAME}" \
+  "${IMAGE_NAME}:${IMAGE_TAG}" /bin/bash

--- a/demos/ros_examples/Dockerfile
+++ b/demos/ros_examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM control-libraries/source-dependencies as ros-dependencies
+FROM epfl-lasa/control-libraries/install as ros-dependencies
 
 # install ROS
 ENV ROS_DISTRO="noetic"
@@ -16,20 +16,7 @@ RUN apt update && apt install -y ros-${ROS_DISTRO}-ros-base \
     sudo \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# create a user with same permissions as the host itself
-ENV USER ros
-ARG UID=1000
-ARG GID=1000
-RUN addgroup --gid ${GID} ${USER}
-RUN adduser --gecos "ROS User" --disabled-password --uid ${UID} --gid ${GID} ${USER}
-RUN usermod -a -G dialout ${USER}
-RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers.d/99_aptget > /dev/null \
-    && chmod 0440 /etc/sudoers.d/99_aptget \
-    && chown root:root /etc/sudoers.d/99_aptget
-
-# change user to the newly created one
-USER ${USER}
-ENV HOME /home/${USER}
+USER developer
 
 # add and build a ros workspace
 ENV ROS_WORKSPACE ${HOME}/ros_ws

--- a/demos/ros_examples/run-demo.sh
+++ b/demos/ros_examples/run-demo.sh
@@ -1,64 +1,68 @@
 #!/usr/bin/env bash
-# change to false if not using nvidia graphic cards
-USE_NVIDIA_TOOLKIT=false
 
-# Build a docker image to compile the library and run tests
 MULTISTAGE_TARGET="runtime-demonstrations"
+IMAGE_NAME=epfl-lasa/control-libraries/ros-examples
+IMAGE_TAG="${MULTISTAGE_TARGET}"
+GPUS=""
+GENERATE_HOST_NAME=true
 
-REBUILD=0
-while getopts 'r' opt; do
-    case $opt in
-        r) REBUILD=1 ;;
-        *) echo 'Error in command line parsing' >&2
-           exit 1
-    esac
+HELP_MESSAGE="Usage: run-demo.sh [-r] [-v]
+Options:
+  --gpus <gpu_options>            Add GPU access for applications that
+                                  require hardware acceleration (e.g. Gazebo)
+                                  For the list of gpu_options parameters see:
+      >>> https://docs.docker.com/config/containers/resource_constraints
+  -r, --rebuild                   Rebuild the image using the docker
+                                  --no-cache option.
+  -v, --verbose                   Use the verbose option during the building
+                                  process.
+  -h, --help                      Show this help message.
+"
+
+BUILD_FLAGS=()
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  case $opt in
+    --no-hostname) GENERATE_HOST_NAME=false; shift 1;;
+    --gpus) GPUS=$2; shift 1;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain); shift ;;
+    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
+    *) echo 'Error in command line parsing' >&2
+       echo -e "\n${HELP_MESSAGE}"
+       exit 1
+  esac
 done
-shift "$(( OPTIND - 1 ))"
 
-PACKAGE_NAME=$(echo "${PWD##*/}" | tr _ -)
-IMAGE_NAME="${PACKAGE_NAME}/$MULTISTAGE_TARGET"
-TAG="latest"
-
-BUILD_FLAGS=(--target "${MULTISTAGE_TARGET}")
-
-if [[ "$OSTYPE" != "darwin"* ]]; then
-  UID="$(id -u "${USER}")"
-  GID="$(id -g "${USER}")"
-  BUILD_FLAGS+=(--build-arg UID="${UID}")
-  BUILD_FLAGS+=(--build-arg GID="${GID}")
-fi
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${TAG}")
-
-if [ "$REBUILD" -eq 1 ]; then
-    BUILD_FLAGS+=(--no-cache)
-fi
-
-MULTISTAGE_SOURCE_TARGET="source-dependencies"
-DOCKER_BUILDKIT=1 docker build --target "${MULTISTAGE_SOURCE_TARGET}" \
-  -t "control-libraries/${MULTISTAGE_SOURCE_TARGET}" \
+docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies
+DOCKER_BUILDKIT=1 docker build --target "install" \
+  -t "epfl-lasa/control-libraries/install" \
+  --build-arg "BUILD_TESTING=OFF" \
+  "${BUILD_FLAGS[@]}" \
   -f ../../source/Dockerfile.source ../../source || exit
-DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" . || exit
 
-#create a shared volume to store rviz config files
-mkdir -p "rviz"
-docker volume create --driver local \
-    --opt type="none" \
-    --opt device="${PWD}/rviz/" \
-    --opt o="bind" \
-    "${PACKAGE_NAME}_rviz_vol"
+DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" . --target "${MULTISTAGE_TARGET}" -t "${IMAGE_NAME}:${IMAGE_TAG}" || exit
 
-[[ ${USE_NVIDIA_TOOLKIT} = true ]] && GPU_FLAG="--gpus all" || GPU_FLAG=""
+RUN_FLAGS=(-u developer)
+if [ -n "${GPUS}" ]; then
+  RUN_FLAGS+=(--gpus "${GPUS}")
+  RUN_FLAGS+=(--env DISPLAY="${DISPLAY}")
+  RUN_FLAGS+=(--env NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES:-all}")
+  RUN_FLAGS+=(--env NVIDIA_DRIVER_CAPABILITIES="${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics")
+fi
 
-xhost +
-docker run \
-  ${GPU_FLAG} \
-  --privileged \
-  -it \
-  --rm \
-  --net="host" \
-  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-  --volume="${XAUTHORITY}:${XAUTHORITY}" \
-  --volume="${PACKAGE_NAME}_rviz_vol:/home/ros/ros_ws/src/ros_examples/rviz/:rw" \
-  --env XAUTHORITY="${XAUTHORITY}" \
-  --env DISPLAY="${DISPLAY}" \
-  "${IMAGE_NAME}:${TAG}"
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+  RUN_FLAGS+=(-e DISPLAY=host.docker.internal:0)
+else
+  xhost +
+  RUN_FLAGS+=(-e DISPLAY="${DISPLAY}")
+  RUN_FLAGS+=(-e XAUTHORITY="${XAUTHORITY}")
+  RUN_FLAGS+=(-v /tmp/.X11-unix:/tmp/.X11-unix:rw)
+  RUN_FLAGS+=(--device=/dev/dri:/dev/dri)
+fi
+
+docker run -it --rm --net="host" \
+  "${RUN_FLAGS[@]}" \
+  --volume="$(pwd)/rviz:/home/ros/ros_ws/src/ros_examples/rviz/:rw" \
+  --name "${CONTAINER_NAME}" \
+  "${IMAGE_NAME}:${IMAGE_TAG}" /bin/bash

--- a/docker/sshd_entrypoint.sh
+++ b/docker/sshd_entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+USERNAME=root
+PUBLIC_KEY=""
+USER_ID=""
+GROUP_ID=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  -k | --key)
+    PUBLIC_KEY=$2
+    shift 2
+    ;;
+  -u | --user)
+    USERNAME=$2
+    shift 2
+    ;;
+  -i | --uid)
+    USER_ID=$2
+    shift 2
+    ;;
+  -g | --gid)
+    GROUP_ID=$2
+    shift 2
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    exit 1
+    ;;
+  esac
+done
+
+# update the USER_ID and GROUP_ID of the specified user
+if [ -n "${USER_ID}" ] && [ -n "${GROUP_ID}" ]; then
+  groupmod -g "${GROUP_ID}" "${USERNAME}"
+  usermod -u "${USER_ID}" -g "${GROUP_ID}" "${USERNAME}"
+fi
+
+if [ -n "${PUBLIC_KEY}" ]; then
+  # authorise the specified user for ssh login
+  HOME="/home/${USERNAME}"
+  mkdir -p "${HOME}"/.ssh
+  echo "${PUBLIC_KEY}" >"${HOME}"/.ssh/authorized_keys
+  chmod -R 755 "${HOME}"/.ssh
+  chown -R "${USERNAME}:${USERNAME}" "${HOME}"/.ssh
+fi
+
+# start the ssh server
+/usr/sbin/sshd -D -e -f /etc/ssh/sshd_config_development

--- a/python/Dockerfile.python
+++ b/python/Dockerfile.python
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest
-FROM ${BASE_IMAGE} AS python-install
+FROM ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest as python-install
 ARG BRANCH=develop
 
 WORKDIR /source
@@ -13,18 +12,12 @@ COPY pyproject.toml setup.py control-libraries/python/
 RUN pip3 install control-libraries/python
 
 
-FROM python-install AS dev-user
+FROM python-install as build-testing
 
-RUN useradd --create-home --shell /bin/bash dev
-USER dev
-WORKDIR /home/dev
+USER developer
+WORKDIR ${HOME}
 
 COPY test ./test
 RUN python3 -m unittest
 
 CMD ["/bin/bash"]
-
-
-FROM python-install AS remote-user
-
-ENTRYPOINT ["/.ssh_entrypoint.sh"]

--- a/python/dev-server.sh
+++ b/python/dev-server.sh
@@ -1,77 +1,118 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-BASE_IMAGE=control-libraries/remote-development:latest
-IMAGE_NAME=control-libraries/python/remote
-CONTAINER_NAME=control-libraries-python-ssh
-CONTAINER_HOSTNAME=control-libraries-python
+IMAGE_NAME=epfl-lasa/control-libraries/python-install
+CONTAINER_NAME=epfl-lasa-control-libraries-python-install-ssh
+
 BRANCH=$(git branch --show-current)
 
 SSH_PORT=2233
-SSH_KEY_FILE="$HOME/.ssh/id_rsa.pub"
+SSH_KEY_FILE="${HOME}/.ssh/id_rsa.pub"
+USERNAME=developer
 
-HELP_MESSAGE="Usage: ./dev-server.sh [--port <port>] [--key-file </path/to/id_rsa.pub>]
+HELP_MESSAGE="Usage: ./dev-server.sh [-p <port>] [-k <file>] [-u <user>] [-r] [-v]
 
 Build and run a docker container as an SSH toolchain server for remote development.
 
 The server is bound to the specified port on localhost (127.0.0.1)
 and uses passwordless RSA key-pair authentication. The host public key
 is read from the specified key file and copied to the server on startup.
+On linux hosts, the UID and GID of the specified user will also be
+set to match the UID and GID of the host user by the entry script.
 
 The server will run in the background as ${CONTAINER_NAME}.
 
-You can connect with 'ssh remote@localhost -p <port>'.
+You can connect with 'ssh <user>@localhost -p <port>'.
 
-Close the server with 'docker container stop ${CONTAINER_NAME}'.
+Close the server with 'docker stop ${CONTAINER_NAME}'.
 
 Options:
-  -b, --branch [branch]    Specify the branch of control libraries
+  -b, --branch <branch>    Specify the branch of control libraries
                            that should be used to build the image.
-  -p, --port [XXXX]        Specify the port to bind for SSH
+  -p, --port <XXXX>        Specify the port to bind for SSH
                            connection.
                            (default: ${SSH_PORT})
-
   -k, --key-file [path]    Specify the path of the RSA
                            public key file.
                            (default: ${SSH_KEY_FILE})
+  -u, --user <user>        Specify the name of the remote user.
+                           (default: ${USERNAME})
+  -r, --rebuild            Rebuild the image using the docker
+                           --no-cache option.
+  -v, --verbose            Use the verbose option during the building
+                           process.
 
-  -h, --help               Show this help message."
+  -h, --help               Show this help message"
 
-function image_not_found() {
-  MESSAGE="Could not find the required Docker image '${BASE_IMAGE}'
-from ../source/Dockerfile.source. Make sure to build it with the 'dev-server.sh' script
-in the 'source' directory."
-  echo "${MESSAGE}" && exit 1
-}
-
-docker image inspect "${BASE_IMAGE}" >/dev/null 2>&1 || image_not_found
-
-BUILD_ARGS=(--build-arg BASE_IMAGE=control-libraries/remote-development:latest)
+FWD_ARGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -b|--branch) BRANCH=$2; shift 2;;
-    -r|--rebuild) BUILD_ARGS+=(--no-cache); shift 1;;
-    -p|--port) SSH_PORT=$2; shift 2;;
-    -k|--key-file) SSH_KEY_FILE=$2; shift 2;;
-    -h|--help) echo "${HELP_MESSAGE}"; exit 0;;
-    *) echo "Unknown option: $1" >&2; echo "${HELP_MESSAGE}"; exit 1;;
+  -p | --port)
+    # only capture the port argument for SSH
+    # the first time, otherwise forward it
+    if [ -z "${CUSTOM_SSH_PORT}" ]; then
+      CUSTOM_SSH_PORT=$2
+    else
+      FWD_ARGS+=("$1 $2")
+    fi
+    shift 2
+    ;;
+  -b|--branch) BRANCH=$2; shift 2;;
+  -k | --key-file) SSH_KEY_FILE=$2; shift 2;;
+  -u | --user) USERNAME=$2; shift 2;;
+  -r|--rebuild) BUILD_FLAGS+=(--no-cache) ; shift ;;
+  -v|--verbose) BUILD_FLAGS+=(--progress=plain) ; shift ;;
+  -h | --help) echo "${HELP_MESSAGE}"; exit 0;;
+  *)
+    echo 'Error in command line parsing' >&2
+    echo -e "\n${HELP_MESSAGE}"
+    exit 1
   esac
 done
 
-echo "Using control libraries branch ${BRANCH}"
-BUILD_ARGS+=(--build-arg BRANCH="${BRANCH}")
+if [ -n "${CUSTOM_SSH_PORT}" ]; then
+  SSH_PORT="${CUSTOM_SSH_PORT}"
+fi
 
+PUBLIC_KEY=$(cat "${SSH_KEY_FILE}")
+
+COMMAND_FLAGS=()
+COMMAND_FLAGS+=(--key "${PUBLIC_KEY}")
+COMMAND_FLAGS+=(--user "${USERNAME}")
+
+RUN_FLAGS=()
+if [[ "${OSTYPE}" != "darwin"* ]]; then
+  USER_ID=$(id -u "${USER}")
+  GROUP_ID=$(id -g "${USER}")
+  COMMAND_FLAGS+=(--uid "${USER_ID}")
+  COMMAND_FLAGS+=(--gid "${GROUP_ID}")
+fi
+
+echo "Using control libraries branch ${BRANCH}"
+BUILD_FLAGS+=(--build-arg BRANCH="${BRANCH}")
+
+docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest
 DOCKER_BUILDKIT=1 docker build . --file ./Dockerfile.python \
-  "${BUILD_ARGS[@]}" \
-  --target remote-user \
+  "${BUILD_FLAGS[@]}" \
+  --target python-install \
   --tag "${IMAGE_NAME}" || exit 1
+
 
 docker container stop "${CONTAINER_NAME}" >/dev/null 2>&1
 docker rm --force "${CONTAINER_NAME}" >/dev/null 2>&1
 
-docker run -d --cap-add sys_ptrace \
+if [ ${#FWD_ARGS[@]} -gt 0 ]; then
+  echo "Forwarding additional arguments to docker run command:"
+  echo "${FWD_ARGS[@]}"
+fi
+
+echo "Starting background container with access port ${SSH_PORT} for user ${USERNAME}"
+docker run -d --rm --cap-add sys_ptrace \
+  --user root \
   --publish 127.0.0.1:"${SSH_PORT}":22 \
   --name "${CONTAINER_NAME}" \
-  --hostname "${CONTAINER_HOSTNAME}" \
-  "${IMAGE_NAME}" "$(cat "${SSH_KEY_FILE}")"
+  --hostname "${CONTAINER_NAME}" \
+  "${RUN_FLAGS[@]}" \
+  "${FWD_ARGS[@]}" \
+  "${IMAGE_NAME}" /sshd_entrypoint.sh "${COMMAND_FLAGS[@]}"
 
 echo "${CONTAINER_NAME}"

--- a/python/dev-server.sh
+++ b/python/dev-server.sh
@@ -59,8 +59,8 @@ while [ "$#" -gt 0 ]; do
   -b|--branch) BRANCH=$2; shift 2;;
   -k | --key-file) SSH_KEY_FILE=$2; shift 2;;
   -u | --user) USERNAME=$2; shift 2;;
-  -r|--rebuild) BUILD_FLAGS+=(--no-cache) ; shift ;;
-  -v|--verbose) BUILD_FLAGS+=(--progress=plain) ; shift ;;
+  -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift ;;
+  -v|--verbose) BUILD_FLAGS+=(--progress=plain); shift ;;
   -h | --help) echo "${HELP_MESSAGE}"; exit 0;;
   *)
     echo 'Error in command line parsing' >&2

--- a/python/run.sh
+++ b/python/run.sh
@@ -18,9 +18,9 @@ BUILD_FLAGS=()
 while [[ $# -gt 0 ]]; do
   opt="$1"
   case $opt in
-    -b|--branch) BRANCH=$2; shift 2;;
-    -r|--rebuild) BUILD_FLAGS+=(--no-cache) ; shift ;;
-    -v|--verbose) BUILD_FLAGS+=(--progress=plain) ; shift ;;
+    -b|--branch) BRANCH=$2;shift 2;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain); shift ;;
     -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
     *) echo 'Error in command line parsing' >&2
        echo -e "\n${HELP_MESSAGE}"

--- a/python/run.sh
+++ b/python/run.sh
@@ -1,26 +1,43 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
+IMAGE_NAME=epfl-lasa/control-libraries/python/test
 BRANCH=$(git branch --show-current)
 
-BUILD_ARGS=()
-while [ "$#" -gt 0 ]; do
-  case "$1" in
+HELP_MESSAGE="Usage: run.sh [-b <branch>] [-r] [-v]
+Options:
+  -b, --branch <branch>           Specify the branch of control libraries
+                                  that should be used to build the image.
+  -r, --rebuild                   Rebuild the image using the docker
+                                  --no-cache option.
+  -v, --verbose                   Use the verbose option during the building
+                                  process.
+  -h, --help                      Show this help message.
+"
+
+BUILD_FLAGS=()
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  case $opt in
     -b|--branch) BRANCH=$2; shift 2;;
-    -r|--rebuild) BUILD_ARGS+=(--no-cache); shift 1;;
-    *) echo "Unknown option: $1" >&2; exit 1;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache) ; shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain) ; shift ;;
+    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
+    *) echo 'Error in command line parsing' >&2
+       echo -e "\n${HELP_MESSAGE}"
+       exit 1
   esac
 done
 
 echo "Using control libraries branch ${BRANCH}"
-BUILD_ARGS+=(--build-arg BRANCH="${BRANCH}")
+BUILD_FLAGS+=(--build-arg BRANCH="${BRANCH}")
 
 docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest
-docker build . --file ./Dockerfile.python \
-  "${BUILD_ARGS[@]}" \
-  --target dev-user \
-  --tag control-libraries/python/test || exit 1
+DOCKER_BUILDKIT=1 docker build . --file ./Dockerfile.python \
+  "${BUILD_FLAGS[@]}" \
+  --target build-testing \
+  --tag "${IMAGE_NAME}" || exit 1
 
 docker run -it --rm \
   --volume "$(pwd)":/source/control-libraries/python \
-  --name control-libraries-python-test \
-  control-libraries/python/test
+  --name "${IMAGE_NAME//[\/.]/-}" \
+  "${IMAGE_NAME}"

--- a/source/Dockerfile.source
+++ b/source/Dockerfile.source
@@ -1,28 +1,4 @@
-FROM ghcr.io/epfl-lasa/control-libraries/development-dependencies as remote-development
-
-RUN ( \
-    echo 'LogLevel DEBUG2'; \
-    echo 'PubkeyAuthentication yes'; \
-    echo 'Subsystem sftp /usr/lib/openssh/sftp-server'; \
-  ) > /etc/ssh/sshd_config_development \
-  && mkdir /run/sshd
-
-RUN useradd -m remote && yes | passwd remote && usermod -s /bin/bash remote
-WORKDIR /home/remote
-
-RUN ( \
-    echo '#!/bin/bash'; \
-    echo 'mkdir -p /home/remote/.ssh'; \
-    echo 'echo "$1" > /home/remote/.ssh/authorized_keys'; \
-    echo 'chmod -R 755 /home/remote/.ssh'; \
-    echo 'chown -R remote:remote /home/remote/.ssh'; \
-    echo '/usr/sbin/sshd -D -e -f /etc/ssh/sshd_config_development'; \
-  ) > /.ssh_entrypoint.sh && chmod 744 /.ssh_entrypoint.sh
-
-ENTRYPOINT ["/.ssh_entrypoint.sh"]
-
-
-FROM ghcr.io/epfl-lasa/control-libraries/development-dependencies as build-testing
+FROM ghcr.io/epfl-lasa/control-libraries/development-dependencies as build
 ARG BUILD_TESTING=ON
 ARG BUILD_CONTROLLERS=ON
 ARG BUILD_DYNAMICAL_SYSTEMS=ON
@@ -38,20 +14,14 @@ RUN cmake -DBUILD_CONTROLLERS="${BUILD_CONTROLLERS}" \
     -DBUILD_TESTING="${BUILD_TESTING}" .. \
   && make -j all
 
+
+FROM build as testing
+
 RUN CTEST_OUTPUT_ON_FAILURE=1 make test
+RUN rm -rf /tmp/control_lib/
 
 
-FROM ghcr.io/epfl-lasa/control-libraries/development-dependencies as source-dependencies
+FROM build as install
 
-WORKDIR /tmp/control_lib
-COPY ./ ./
-
-WORKDIR /tmp/control_lib/build
-RUN cmake -DBUILD_CONTROLLERS="ON" \
-    -DBUILD_DYNAMICAL_SYSTEMS="ON" \
-    -DBUILD_ROBOT_MODEL="ON" \
-    -DBUILD_TESTING="OFF" .. \
-  && make -j all \
-  && make install
-
+RUN make install
 RUN rm -rf /tmp/control_lib/

--- a/source/build-test.sh
+++ b/source/build-test.sh
@@ -23,9 +23,9 @@ BUILD_FLAGS=()
 while [[ $# -gt 0 ]]; do
   opt="$1"
   case $opt in
-    -r|--rebuild) BUILD_FLAGS+=(--no-cache) ; shift ;;
-    -v|--verbose) BUILD_FLAGS+=(--progress=plain) ; shift ;;
-    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain); shift ;;
+    -h|--help) echo "${HELP_MESSAGE}"; exit 0 ;;
     *) echo 'Error in command line parsing' >&2
        echo -e "\n${HELP_MESSAGE}"
        exit 1

--- a/source/build-test.sh
+++ b/source/build-test.sh
@@ -12,10 +12,12 @@ BUILD_ROBOT_MODEL="ON"
 HELP_MESSAGE="Usage: build-test.sh [-r] [-v]
 Options:
   -r, --rebuild                   Rebuild the image using the docker
-                                  --no-cache option
+                                  --no-cache option.
   -v, --verbose                   Use the verbose option during the building
-                                  process
+                                  process.
+  -h, --help                      Show this help message.
 "
+
 BUILD_FLAGS=()
 
 while [[ $# -gt 0 ]]; do

--- a/source/build-test.sh
+++ b/source/build-test.sh
@@ -1,35 +1,41 @@
 #!/usr/bin/env bash
-# Build a docker image to compile the library and run tests
 
-MULTISTAGE_TARGET="build-testing"
+MULTISTAGE_TARGET="testing"
+IMAGE_NAME=epfl-lasa/control-libraries/source/"${MULTISTAGE_TARGET}"
+IMAGE_TAG="latest"
+
 BUILD_TESTING="ON"
 BUILD_CONTROLLERS="ON"
 BUILD_DYNAMICAL_SYSTEMS="ON"
 BUILD_ROBOT_MODEL="ON"
 
-REBUILD=0
-while getopts 'r' opt; do
-    case $opt in
-        r) REBUILD=1 ;;
-        *) echo 'Error in command line parsing' >&2
-           exit 1
-    esac
-done
-shift "$(( OPTIND - 1 ))"
+HELP_MESSAGE="Usage: build-test.sh [-r] [-v]
+Options:
+  -r, --rebuild                   Rebuild the image using the docker
+                                  --no-cache option
+  -v, --verbose                   Use the verbose option during the building
+                                  process
+"
+BUILD_FLAGS=()
 
-NAME=epfl-lasa/control-libraries/source/"${MULTISTAGE_TARGET}"
-TAG="latest"
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  case $opt in
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache) ; shift ;;
+    -v|--verbose) BUILD_FLAGS+=(--progress=plain) ; shift ;;
+    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
+    *) echo 'Error in command line parsing' >&2
+       echo -e "\n${HELP_MESSAGE}"
+       exit 1
+  esac
+done
 
 BUILD_FLAGS=(--target "${MULTISTAGE_TARGET}")
 BUILD_FLAGS+=(--build-arg "BUILD_TESTING=${BUILD_TESTING}")
 BUILD_FLAGS+=(--build-arg "BUILD_CONTROLLERS=${BUILD_CONTROLLERS}")
 BUILD_FLAGS+=(--build-arg "BUILD_DYNAMICAL_SYSTEMS=${BUILD_DYNAMICAL_SYSTEMS}")
 BUILD_FLAGS+=(--build-arg "BUILD_ROBOT_MODEL=${BUILD_ROBOT_MODEL}")
-BUILD_FLAGS+=(-t "${NAME}:${TAG}")
-
-if [ "$REBUILD" -eq 1 ]; then
-    BUILD_FLAGS+=(--no-cache)
-fi
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${IMAGE_TAG}")
 
 docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies
 DOCKER_BUILDKIT=1 docker build . --file ./Dockerfile.source "${BUILD_FLAGS[@]}"

--- a/source/dev-server.sh
+++ b/source/dev-server.sh
@@ -1,29 +1,30 @@
 #!/usr/bin/env bash
 
-IMAGE_NAME=control-libraries/remote-development
-STAGE_NAME=remote-development
-CONTAINER_NAME=control-libraries-remote-development-ssh
-CONTAINER_HOSTNAME=control-libraries-remote-development
+IMAGE_NAME=ghcr.io/epfl-lasa/control-libraries/development-dependencies
+CONTAINER_NAME=epfl-lasa-control-libraries-development-dependencies-ssh
 
 SSH_PORT=2222
-SSH_KEY_FILE="$HOME/.ssh/id_rsa.pub"
+SSH_KEY_FILE="${HOME}/.ssh/id_rsa.pub"
+USERNAME=developer
 
-HELP_MESSAGE="Usage: ./dev-server.sh [--port <port>] [--key-file </path/to/id_rsa.pub>]
+HELP_MESSAGE="Usage: ./dev-server.sh [-p <port>] [-k <file>] [-u <user>]
 
 Build and run a docker container as an SSH toolchain server for remote development.
 
 The server is bound to the specified port on localhost (127.0.0.1)
 and uses passwordless RSA key-pair authentication. The host public key
 is read from the specified key file and copied to the server on startup.
+On linux hosts, the UID and GID of the specified user will also be
+set to match the UID and GID of the host user by the entry script.
 
 The server will run in the background as ${CONTAINER_NAME}.
 
-You can connect with 'ssh remote@localhost -p <port>'.
+You can connect with 'ssh <user>@localhost -p <port>'.
 
-Close the server with 'docker container stop ${CONTAINER_NAME}'.
+Close the server with 'docker stop ${CONTAINER_NAME}'.
 
 Options:
-  -p, --port [XXXX]        Specify the port to bind for SSH
+  -p, --port <XXXX>        Specify the port to bind for SSH
                            connection.
                            (default: ${SSH_PORT})
 
@@ -31,25 +32,70 @@ Options:
                            public key file.
                            (default: ${SSH_KEY_FILE})
 
-  -h, --help               Show this help message."
+  -u, --user <user>        Specify the name of the remote user.
+                           (default: ${USERNAME})
 
+  -h, --help               Show this help message"
+
+FWD_ARGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -p|--port) SSH_PORT=$2; shift 2;;
-    -k|--key-file) SSH_KEY_FILE=$2; shift 2;;
-    -h|--help) echo "${HELP_MESSAGE}"; exit 0;;
-    *) echo "Unknown option: $1" >&2; echo "${HELP_MESSAGE}"; exit 1;;
+  -p | --port)
+    # only capture the port argument for SSH
+    # the first time, otherwise forward it
+    if [ -z "${CUSTOM_SSH_PORT}" ]; then
+      CUSTOM_SSH_PORT=$2
+    else
+      FWD_ARGS+=("$1 $2")
+    fi
+    shift 2
+    ;;
+  -k | --key-file) SSH_KEY_FILE=$2; shift 2;;
+  -u | --user) USERNAME=$2; shift 2;;
+  -h | --help) echo "${HELP_MESSAGE}"; exit 0;;
+  *)
+    echo 'Error in command line parsing' >&2
+    echo -e "\n${HELP_MESSAGE}"
+    exit 1
   esac
 done
 
-docker pull ghcr.io/epfl-lasa/control-libraries/development-dependencies
-DOCKER_BUILDKIT=1 docker build . --file ./Dockerfile.source --target "${STAGE_NAME}" --tag "${IMAGE_NAME}"
+if [ -n "${CUSTOM_SSH_PORT}" ]; then
+  SSH_PORT="${CUSTOM_SSH_PORT}"
+fi
+
+PUBLIC_KEY=$(cat "${SSH_KEY_FILE}")
+
+COMMAND_FLAGS=()
+COMMAND_FLAGS+=(--key "${PUBLIC_KEY}")
+COMMAND_FLAGS+=(--user "${USERNAME}")
+
+RUN_FLAGS=()
+if [[ "${OSTYPE}" != "darwin"* ]]; then
+  USER_ID=$(id -u "${USER}")
+  GROUP_ID=$(id -g "${USER}")
+  COMMAND_FLAGS+=(--uid "${USER_ID}")
+  COMMAND_FLAGS+=(--gid "${GROUP_ID}")
+fi
+
+docker pull "${IMAGE_NAME}" || exit 1
 
 docker container stop "${CONTAINER_NAME}" >/dev/null 2>&1
 docker rm --force "${CONTAINER_NAME}" >/dev/null 2>&1
 
-docker run -d --cap-add sys_ptrace \
+if [ ${#FWD_ARGS[@]} -gt 0 ]; then
+  echo "Forwarding additional arguments to docker run command:"
+  echo "${FWD_ARGS[@]}"
+fi
+
+echo "Starting background container with access port ${SSH_PORT} for user ${USERNAME}"
+docker run -d --rm --cap-add sys_ptrace \
+  --user root \
   --publish 127.0.0.1:"${SSH_PORT}":22 \
   --name "${CONTAINER_NAME}" \
-  --hostname "${CONTAINER_HOSTNAME}" \
-  "${IMAGE_NAME}" "$(cat "${SSH_KEY_FILE}")"
+  --hostname "${CONTAINER_NAME}" \
+  "${RUN_FLAGS[@]}" \
+  "${FWD_ARGS[@]}" \
+  "${IMAGE_NAME}" /sshd_entrypoint.sh "${COMMAND_FLAGS[@]}"
+
+echo "${CONTAINER_NAME}"

--- a/source/dev-server.sh
+++ b/source/dev-server.sh
@@ -27,14 +27,11 @@ Options:
   -p, --port <XXXX>        Specify the port to bind for SSH
                            connection.
                            (default: ${SSH_PORT})
-
   -k, --key-file [path]    Specify the path of the RSA
                            public key file.
                            (default: ${SSH_KEY_FILE})
-
   -u, --user <user>        Specify the name of the remote user.
                            (default: ${USERNAME})
-
   -h, --help               Show this help message"
 
 FWD_ARGS=()


### PR DESCRIPTION
Hi guys, so I've been working on that image for the network-interfaces and I realized that we always have to configure a remote user when we use control-libraries/Development-dependencies, and its always the same lines we have to use everywhere.

So I'm suggestion to put that user configuration into the base dockerfile of control-libraries, equivalent to the ros2_ws image. This would allow us internally to use aica-docker commands with images that are based on control-libraries/development-dependencies. Now I'm quite sure this will require some discussions between us, which is why this PR is not finished yet. In particular, I need to have the  `sshd_entypoint` script somewhere so I can copy it in the image, so I'm wondering what to do there. Cloning docker-images and copying the file from there might not be the best approach because we always said we wanna have control libraries independent from docker-images.

What do you think? Is this something you find acceptable and if yes, how should we handle the entrypoint script? I personally think it would be useful because again, we are the only users of control libraries and we can even make the `build-test.sh` and `dev-server.sh`  scripts here work without aica-docker commands.