### PR TITLE
ParameterMap base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Release Versions:
 - Mark the JointState as filled when one index was set (#245)
 - Add user sshd configuration and user 'developer' in base Dockerfile 
   and update all the Dockerfiles and scripts (#244, #246)
+- Add ParameterMap base class (#247)
 
 ### Pending TODOs for the next release
 

--- a/source/dynamical_systems/include/dynamical_systems/DefaultDynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/DefaultDynamicalSystem.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "dynamical_systems/IDynamicalSystem.hpp"
-#include "dynamical_systems/exceptions/InvalidParameterException.hpp"
+#include "state_representation/exceptions/InvalidParameterException.hpp"
 
 namespace dynamical_systems {
 
@@ -25,8 +25,10 @@ private:
 };
 
 template<class S>
-void DefaultDynamicalSystem<S>::validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>&) {
-  throw exceptions::InvalidParameterException("No parameter to be set on this type of DS.");
+void DefaultDynamicalSystem<S>::validate_and_set_parameter(
+    const std::shared_ptr<state_representation::ParameterInterface>&
+) {
+  throw state_representation::exceptions::InvalidParameterException("No parameter to be set on this type of DS.");
 }
 
 template<class S>

--- a/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
+++ b/source/dynamical_systems/include/dynamical_systems/IDynamicalSystem.hpp
@@ -4,8 +4,7 @@
 #include <map>
 #include <memory>
 
-#include "dynamical_systems/exceptions/InvalidParameterException.hpp"
-#include "state_representation/parameters/Parameter.hpp"
+#include "state_representation/parameters/ParameterMap.hpp"
 
 /**
  * @namespace dynamical_systems
@@ -19,7 +18,7 @@ namespace dynamical_systems {
  * @tparam S Underlying state type of the dynamical system
  */
 template<class S>
-class IDynamicalSystem {
+class IDynamicalSystem : public state_representation::ParameterMap {
 public:
   /**
    * @brief Empty constructor
@@ -52,62 +51,6 @@ public:
    */
   virtual void set_base_frame(const S& base_frame);
 
-  /**
-   * @brief Get a parameter of the dynamical system by its name.
-   * @param name The name of the parameter
-   * @return The parameter, if it exists
-   */
-  [[nodiscard]] std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name) const;
-
-  /**
-   * @brief Get a map of all the <name, parameter> pairs of the dynamical system.
-   * @return The map of parameters
-   */
-  [[nodiscard]] std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const;
-
-  /**
-   * @brief Get a parameter of the dynamical system by its name.
-   * @tparam T Type of the parameter value
-   * @param name The name of the parameter
-   * @return The value of the parameter, if the parameter exists
-   */
-  template<typename T>
-  [[nodiscard]] T get_parameter_value(const std::string& name) const;
-
-  /**
-   * @brief Get a list of all the parameters of the dynamical system.
-   * @return The list of parameters
-   */
-  [[nodiscard]] std::list<std::shared_ptr<state_representation::ParameterInterface>> get_parameter_list() const;
-
-  /**
-   * @brief Set a parameter of the dynamical system.
-   * @param parameter The new parameter
-   */
-  void set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
-
-  /**
-   * @brief Set parameters of the dynamical list from a list of parameters.
-   * @param parameters The list of parameters
-   */
-  void set_parameters(const std::list<std::shared_ptr<state_representation::ParameterInterface>>& parameters);
-
-  /**
-   * @brief Set parameters of the dynamical system from a map with <name, parameter> pairs.
-   * @param parameters The map of parameters
-   */
-  void
-  set_parameters(const std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>& parameters);
-
-  /**
-   * @brief Set a parameter value of the dynamical system found by its name.
-   * @tparam T Type of the parameter value
-   * @param name The name of the parameter
-   * @param value The new value of the parameter
-   */
-  template<typename T>
-  void set_parameter_value(const std::string& name, const T& value);
-
 protected:
   /**
    * @brief Compute the dynamics of the input state. Internal function,
@@ -118,38 +61,9 @@ protected:
    */
   [[nodiscard]] virtual S compute_dynamics(const S& state) const = 0;
 
-  /**
-   * @brief Check if a parameter has the expected type, throw an exception otherwise.
-   * @param parameter The parameter to be validated
-   */
-  void assert_parameter_valid(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
-
-  /**
-   * @brief Validate and set a parameter of the dynamical system.
-   * @details Internal function, to be redefined based on the
-   * dynamical system, called by the set_parameter function.
-   * @param parameter The parameter to be validated
-   */
-  virtual void
-  validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) = 0;
-
-  std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>
-      param_map_; ///< map containing the names and values of all parameters of the dynamical system
-
 private:
   S base_frame_; ///< frame in which the dynamical system is expressed
 };
-
-template<class S>
-void IDynamicalSystem<S>::assert_parameter_valid(
-    const std::shared_ptr<state_representation::ParameterInterface>& parameter
-) {
-  if (this->param_map_.at(parameter->get_name())->get_type() != parameter->get_type()) {
-    throw dynamical_systems::exceptions::InvalidParameterException(
-        "Parameter '" + parameter->get_name() + "' exists, but has unexpected type."
-    );
-  }
-}
 
 template<class S>
 S IDynamicalSystem<S>::get_base_frame() const {
@@ -161,62 +75,4 @@ void IDynamicalSystem<S>::set_base_frame(const S& base_frame) {
   this->base_frame_ = base_frame;
 }
 
-template<class S>
-std::shared_ptr<state_representation::ParameterInterface> IDynamicalSystem<S>::get_parameter(const std::string& name) const {
-  if (this->param_map_.find(name) == this->param_map_.cend()) {
-    throw exceptions::InvalidParameterException("Could not find a parameter named '" + name + "'.");
-  }
-  return this->param_map_.at(name);
-}
-
-template<class S>
-template<typename T>
-T IDynamicalSystem<S>::get_parameter_value(const std::string& name) const {
-  return std::static_pointer_cast<state_representation::Parameter<T>>(this->get_parameter(name))->get_value();
-}
-
-template<class S>
-std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>
-IDynamicalSystem<S>::get_parameters() const {
-  return this->param_map_;
-}
-
-template<class S>
-std::list<std::shared_ptr<state_representation::ParameterInterface>> IDynamicalSystem<S>::get_parameter_list() const {
-  std::list<std::shared_ptr<state_representation::ParameterInterface>> param_list;
-  for (const auto& param_it: this->param_map_) {
-    param_list.template emplace_back(param_it.second);
-  }
-  return param_list;
-}
-
-template<class S>
-void IDynamicalSystem<S>::set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
-  this->validate_and_set_parameter(parameter);
-}
-
-template<class S>
-void IDynamicalSystem<S>::set_parameters(
-    const std::list<std::shared_ptr<state_representation::ParameterInterface>>& parameters
-) {
-  for (const auto& param: parameters) {
-    this->set_parameter(param);
-  }
-}
-
-template<class S>
-void IDynamicalSystem<S>::set_parameters(
-    const std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>& parameters
-) {
-  for (const auto& param_it: parameters) {
-    this->set_parameter(param_it.second);
-  }
-}
-
-template<class S>
-template<typename T>
-void IDynamicalSystem<S>::set_parameter_value(const std::string& name, const T& value) {
-  using namespace state_representation;
-  this->validate_and_set_parameter(std::make_shared<Parameter<T>>(Parameter<T>(name, value)));
-}
 }// namespace dynamical_systems

--- a/source/dynamical_systems/src/Circular.cpp
+++ b/source/dynamical_systems/src/Circular.cpp
@@ -15,10 +15,10 @@ Circular::Circular() :
     normal_gain_(std::make_shared<Parameter<double>>("normal_gain", 1.0)),
     circular_velocity_(std::make_shared<Parameter<double>>("circular_velocity", M_PI / 2)) {
   this->limit_cycle_->get_value().set_center_state(CartesianState("limit_cycle", "limit_cycle"));
-  this->param_map_.insert(std::make_pair("limit_cycle", this->limit_cycle_));
-  this->param_map_.insert(std::make_pair("planar_gain", this->planar_gain_));
-  this->param_map_.insert(std::make_pair("normal_gain", this->normal_gain_));
-  this->param_map_.insert(std::make_pair("circular_velocity", this->circular_velocity_));
+  this->parameters_.insert(std::make_pair("limit_cycle", this->limit_cycle_));
+  this->parameters_.insert(std::make_pair("planar_gain", this->planar_gain_));
+  this->parameters_.insert(std::make_pair("normal_gain", this->normal_gain_));
+  this->parameters_.insert(std::make_pair("circular_velocity", this->circular_velocity_));
 }
 
 void Circular::set_limit_cycle(Ellipsoid& limit_cycle) {

--- a/source/dynamical_systems/src/Circular.cpp
+++ b/source/dynamical_systems/src/Circular.cpp
@@ -1,7 +1,7 @@
 #include "dynamical_systems/Circular.hpp"
 
 #include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
-#include "dynamical_systems/exceptions/InvalidParameterException.hpp"
+#include "state_representation/exceptions/InvalidParameterException.hpp"
 
 #include "state_representation/exceptions/EmptyStateException.hpp"
 
@@ -36,8 +36,7 @@ void Circular::set_limit_cycle(Ellipsoid& limit_cycle) {
       throw state_representation::exceptions::IncompatibleReferenceFramesException(
           "The reference frame of the center " + center.get_name() + " in frame " + center.get_reference_frame()
               + " is incompatible with the base frame of the dynamical system " + this->get_base_frame().get_name()
-              + " in frame " + this->get_base_frame().get_reference_frame() + "."
-      );
+              + " in frame " + this->get_base_frame().get_reference_frame() + ".");
     }
     limit_cycle.set_center_state(this->get_base_frame().inverse() * center);
   }
@@ -71,7 +70,8 @@ void Circular::validate_and_set_parameter(const std::shared_ptr<ParameterInterfa
     this->assert_parameter_valid(parameter);
     this->circular_velocity_->set_value(std::static_pointer_cast<Parameter<double>>(parameter)->get_value());
   } else {
-    throw exceptions::InvalidParameterException("No parameter with name '" + parameter->get_name() + "' found");
+    throw state_representation::exceptions::InvalidParameterException(
+        "No parameter with name '" + parameter->get_name() + "' found");
   }
 }
 

--- a/source/dynamical_systems/src/PointAttractor.cpp
+++ b/source/dynamical_systems/src/PointAttractor.cpp
@@ -19,16 +19,16 @@ template<>
 PointAttractor<CartesianState>::PointAttractor() :
     attractor_(std::make_shared<Parameter<CartesianState>>(Parameter<CartesianPose>("attractor", CartesianPose()))),
     gain_(std::make_shared<Parameter<Eigen::MatrixXd>>("gain", Eigen::MatrixXd::Identity(6, 6))) {
-  this->param_map_.insert(std::make_pair("attractor", attractor_));
-  this->param_map_.insert(std::make_pair("gain", gain_));
+  this->parameters_.insert(std::make_pair("attractor", attractor_));
+  this->parameters_.insert(std::make_pair("gain", gain_));
 }
 
 template<>
 PointAttractor<JointState>::PointAttractor() :
     attractor_(std::make_shared<Parameter<JointState>>(Parameter<JointPositions>("attractor"))),
     gain_(std::make_shared<Parameter<Eigen::MatrixXd>>("gain")) {
-  this->param_map_.insert(std::make_pair("attractor", attractor_));
-  this->param_map_.insert(std::make_pair("gain", gain_));
+  this->parameters_.insert(std::make_pair("attractor", attractor_));
+  this->parameters_.insert(std::make_pair("gain", gain_));
 }
 
 template<class S>

--- a/source/dynamical_systems/src/PointAttractor.cpp
+++ b/source/dynamical_systems/src/PointAttractor.cpp
@@ -2,7 +2,7 @@
 
 #include "dynamical_systems/exceptions/NotImplementedException.hpp"
 #include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
-#include "dynamical_systems/exceptions/InvalidParameterException.hpp"
+#include "state_representation/exceptions/InvalidParameterException.hpp"
 #include "dynamical_systems/exceptions/IncompatibleSizeException.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
@@ -77,7 +77,7 @@ void PointAttractor<S>::set_gain(const std::shared_ptr<ParameterInterface>& para
     }
     this->gain_->set_value(gain->get_value());
   } else {
-    throw exceptions::InvalidParameterException("Parameter 'gain' has incorrect type");
+    throw state_representation::exceptions::InvalidParameterException("Parameter 'gain' has incorrect type");
   }
 }
 
@@ -149,7 +149,7 @@ void PointAttractor<CartesianState>::validate_and_set_parameter(const std::share
   } else if (parameter->get_name() == "gain") {
     this->set_gain(parameter, 6);
   } else {
-    throw exceptions::InvalidParameterException("No parameter with name '" + parameter->get_name() + "' found");
+    throw state_representation::exceptions::InvalidParameterException("No parameter with name '" + parameter->get_name() + "' found");
   }
 }
 
@@ -160,7 +160,7 @@ void PointAttractor<JointState>::validate_and_set_parameter(const std::shared_pt
   } else if (parameter->get_name() == "gain") {
     this->set_gain(parameter, this->attractor_->get_value().get_size());
   } else {
-    throw exceptions::InvalidParameterException("No parameter with name '" + parameter->get_name() + "' found");
+    throw state_representation::exceptions::InvalidParameterException("No parameter with name '" + parameter->get_name() + "' found");
   }
 }
 

--- a/source/dynamical_systems/src/Ring.cpp
+++ b/source/dynamical_systems/src/Ring.cpp
@@ -1,7 +1,7 @@
 #include "dynamical_systems/Ring.hpp"
 
 #include "dynamical_systems/exceptions/EmptyAttractorException.hpp"
-#include "dynamical_systems/exceptions/InvalidParameterException.hpp"
+#include "state_representation/exceptions/InvalidParameterException.hpp"
 #include "state_representation/space/cartesian/CartesianTwist.hpp"
 #include "state_representation/exceptions/IncompatibleReferenceFramesException.hpp"
 #include "state_representation/exceptions/EmptyStateException.hpp"
@@ -46,8 +46,7 @@ void Ring::set_center(const CartesianPose& center) {
       throw state_representation::exceptions::IncompatibleReferenceFramesException(
           "The reference frame of the center " + center.get_name() + " in frame " + center.get_reference_frame()
               + " is incompatible with the base frame of the dynamical system " + this->get_base_frame().get_name()
-              + " in frame " + this->get_base_frame().get_reference_frame() + "."
-      );
+              + " in frame " + this->get_base_frame().get_reference_frame() + ".");
     }
     this->center_->set_value(this->get_base_frame().inverse() * center);
   } else {
@@ -104,7 +103,8 @@ void Ring::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>&
     this->assert_parameter_valid(parameter);
     this->angular_gain_->set_value(std::static_pointer_cast<Parameter<double>>(parameter)->get_value());
   } else {
-    throw exceptions::InvalidParameterException("No parameter with name '" + parameter->get_name() + "' found");
+    throw state_representation::exceptions::InvalidParameterException(
+        "No parameter with name '" + parameter->get_name() + "' found");
   }
 }
 
@@ -212,8 +212,7 @@ CartesianState Ring::compute_dynamics(const CartesianState& state) const {
   twist.set_linear_velocity(this->calculate_local_linear_velocity(pose, local_field_strength));
   twist.set_angular_velocity(
       this->calculate_local_angular_velocity(
-          pose, twist.get_linear_velocity(), local_field_strength
-      ));
+          pose, twist.get_linear_velocity(), local_field_strength));
 
   // transform the twist back to the base reference frame
   return CartesianState(this->center_->get_value()) * twist;

--- a/source/dynamical_systems/src/Ring.cpp
+++ b/source/dynamical_systems/src/Ring.cpp
@@ -22,14 +22,14 @@ Ring::Ring() :
   this->center_->get_value().set_empty();
   this->rotation_offset_->set_value(
       CartesianPose("rotation", Eigen::Quaterniond::Identity(), this->center_->get_value().get_name()));
-  this->param_map_.insert(std::make_pair("center", this->center_));
-  this->param_map_.insert(std::make_pair("rotation_offset", this->rotation_offset_));
-  this->param_map_.insert(std::make_pair("radius", this->radius_));
-  this->param_map_.insert(std::make_pair("width", this->width_));
-  this->param_map_.insert(std::make_pair("speed", this->speed_));
-  this->param_map_.insert(std::make_pair("field_strength", this->field_strength_));
-  this->param_map_.insert(std::make_pair("normal_gain", this->normal_gain_));
-  this->param_map_.insert(std::make_pair("angular_gain", this->angular_gain_));
+  this->parameters_.insert(std::make_pair("center", this->center_));
+  this->parameters_.insert(std::make_pair("rotation_offset", this->rotation_offset_));
+  this->parameters_.insert(std::make_pair("radius", this->radius_));
+  this->parameters_.insert(std::make_pair("width", this->width_));
+  this->parameters_.insert(std::make_pair("speed", this->speed_));
+  this->parameters_.insert(std::make_pair("field_strength", this->field_strength_));
+  this->parameters_.insert(std::make_pair("normal_gain", this->normal_gain_));
+  this->parameters_.insert(std::make_pair("angular_gain", this->angular_gain_));
 }
 
 void Ring::set_center(const CartesianPose& center) {

--- a/source/dynamical_systems/test/tests/test_factory.cpp
+++ b/source/dynamical_systems/test/tests/test_factory.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "dynamical_systems/DynamicalSystemFactory.hpp"
-#include "dynamical_systems/exceptions/InvalidParameterException.hpp"
+#include "state_representation/exceptions/InvalidParameterException.hpp"
 
 #include "state_representation/space/cartesian/CartesianState.hpp"
 #include "state_representation/robot/JointState.hpp"
@@ -20,7 +20,7 @@ TEST(DSFactoryTest, CreateDS) {
   ASSERT_NO_THROW(auto res = cart_ds->evaluate(CartesianState::Identity("C", "A")));
   EXPECT_TRUE(cart_ds->evaluate(CartesianState::Identity("C", "A")).is_empty());
   EXPECT_EQ(cart_ds->get_parameters().size(), 0);
-  EXPECT_THROW(cart_ds->set_parameters(param_list), dynamical_systems::exceptions::InvalidParameterException);
+  EXPECT_THROW(cart_ds->set_parameters(param_list), exceptions::InvalidParameterException);
 
   auto joint_ds = dynamical_systems::DynamicalSystemFactory<JointState>::create_dynamical_system(
       dynamical_systems::DynamicalSystemFactory<JointState>::DYNAMICAL_SYSTEM::NONE
@@ -28,5 +28,5 @@ TEST(DSFactoryTest, CreateDS) {
   ASSERT_NO_THROW(auto res = joint_ds->evaluate(JointState::Random("robot", 3)));
   EXPECT_TRUE(joint_ds->evaluate(JointState::Random("robot", 3)).is_empty());
   EXPECT_EQ(joint_ds->get_parameters().size(), 0);
-  EXPECT_THROW(joint_ds->set_parameters(param_list), dynamical_systems::exceptions::InvalidParameterException);
+  EXPECT_THROW(joint_ds->set_parameters(param_list), exceptions::InvalidParameterException);
 }

--- a/source/state_representation/include/state_representation/exceptions/InvalidParameterException.hpp
+++ b/source/state_representation/include/state_representation/exceptions/InvalidParameterException.hpp
@@ -2,7 +2,7 @@
 
 #include <exception>
 
-namespace dynamical_systems::exceptions {
+namespace state_representation::exceptions {
 class InvalidParameterException : public std::runtime_error {
 public:
   explicit InvalidParameterException(const std::string& msg) : runtime_error(msg) {};

--- a/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
@@ -90,16 +90,16 @@ protected:
   void assert_parameter_valid(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
 
   std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>
-      param_map_; ///< map of parameters by name
+      parameters_; ///< map of parameters by name
 
 };
 
 inline std::shared_ptr<state_representation::ParameterInterface>
 ParameterMap::get_parameter(const std::string& name) const {
-  if (this->param_map_.find(name) == this->param_map_.cend()) {
+  if (this->parameters_.find(name) == this->parameters_.cend()) {
     throw exceptions::InvalidParameterException("Could not find a parameter named '" + name + "'.");
   }
-  return this->param_map_.at(name);
+  return this->parameters_.at(name);
 }
 
 template<typename T>
@@ -109,12 +109,12 @@ inline T ParameterMap::get_parameter_value(const std::string& name) const {
 
 inline std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>
 ParameterMap::get_parameters() const {
-  return this->param_map_;
+  return this->parameters_;
 }
 
 inline std::list<std::shared_ptr<state_representation::ParameterInterface>> ParameterMap::get_parameter_list() const {
   std::list<std::shared_ptr<state_representation::ParameterInterface>> param_list;
-  for (const auto& param_it: this->param_map_) {
+  for (const auto& param_it: this->parameters_) {
     param_list.template emplace_back(param_it.second);
   }
   return param_list;
@@ -149,7 +149,7 @@ inline void ParameterMap::set_parameter_value(const std::string& name, const T& 
 inline void ParameterMap::assert_parameter_valid(
     const std::shared_ptr<state_representation::ParameterInterface>& parameter
 ) {
-  if (this->param_map_.at(parameter->get_name())->get_type() != parameter->get_type()) {
+  if (this->parameters_.at(parameter->get_name())->get_type() != parameter->get_type()) {
     throw exceptions::InvalidParameterException(
         "Parameter '" + parameter->get_name() + "' exists, but has unexpected type.");
   }
@@ -157,7 +157,7 @@ inline void ParameterMap::assert_parameter_valid(
 
 inline void
 ParameterMap::validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
-  this->param_map_[parameter->get_name()] = parameter;
+  this->parameters_[parameter->get_name()] = parameter;
 }
 
 }

--- a/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
+++ b/source/state_representation/include/state_representation/parameters/ParameterMap.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+#include "state_representation/exceptions/InvalidParameterException.hpp"
+#include "state_representation/parameters/Parameter.hpp"
+
+namespace state_representation {
+
+/**
+ * @class ParameterMap
+ * @brief A wrapper class to contain a map of Parameter pointers by name and provide robust access methods
+ */
+class ParameterMap {
+public:
+
+  /**
+   * @brief Empty constructor
+   */
+  ParameterMap() = default;
+
+  /**
+   * @brief Get a parameter by its name.
+   * @param name The name of the parameter
+   * @return The parameter, if it exists
+   */
+  [[nodiscard]] std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name) const;
+
+  /**
+   * @brief Get a map of all the <name, parameter> pairs.
+   * @return The map of parameters
+   */
+  [[nodiscard]] std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>> get_parameters() const;
+
+  /**
+   * @brief Get a parameter value by its name.
+   * @tparam T Type of the parameter value
+   * @param name The name of the parameter
+   * @return The value of the parameter, if the parameter exists
+   */
+  template<typename T>
+  [[nodiscard]] T get_parameter_value(const std::string& name) const;
+
+  /**
+   * @brief Get a list of all the parameters.
+   * @return The list of parameters
+   */
+  [[nodiscard]] std::list<std::shared_ptr<state_representation::ParameterInterface>> get_parameter_list() const;
+
+  /**
+   * @brief Set a parameter.
+   * @param parameter The new parameter
+   */
+  void set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
+
+  /**
+   * @brief Set parameters from a list of parameters.
+   * @param parameters The list of parameters
+   */
+  void set_parameters(const std::list<std::shared_ptr<state_representation::ParameterInterface>>& parameters);
+
+  /**
+   * @brief Set parameters from a map with <name, parameter> pairs.
+   * @param parameters The map of parameters
+   */
+  void
+  set_parameters(const std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>& parameters);
+
+  /**
+   * @brief Set a parameter value by its name.
+   * @tparam T Type of the parameter value
+   * @param name The name of the parameter
+   * @param value The new value of the parameter
+   */
+  template<typename T>
+  void set_parameter_value(const std::string& name, const T& value);
+
+protected:
+
+  /**
+   * @brief Validate and set a parameter in the map.
+   * @details This virtual function should be redefined in any base class to provide proper validation of parameters
+   * by name, value and type. In the base form, it allows any type of parameter name to be added to the map.
+   * @param parameter The parameter to be validated
+   */
+  virtual void validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
+
+  /**
+   * @brief Check if a parameter has the expected type, throw an exception otherwise.
+   * @param parameter The parameter to be validated
+   */
+  void assert_parameter_valid(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
+
+  std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>
+      param_map_; ///< map of parameters by name
+
+};
+
+inline std::shared_ptr<state_representation::ParameterInterface>
+ParameterMap::get_parameter(const std::string& name) const {
+  if (this->param_map_.find(name) == this->param_map_.cend()) {
+    throw exceptions::InvalidParameterException("Could not find a parameter named '" + name + "'.");
+  }
+  return this->param_map_.at(name);
+}
+
+template<typename T>
+inline T ParameterMap::get_parameter_value(const std::string& name) const {
+  return std::static_pointer_cast<state_representation::Parameter<T>>(this->get_parameter(name))->get_value();
+}
+
+inline std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>
+ParameterMap::get_parameters() const {
+  return this->param_map_;
+}
+
+inline std::list<std::shared_ptr<state_representation::ParameterInterface>> ParameterMap::get_parameter_list() const {
+  std::list<std::shared_ptr<state_representation::ParameterInterface>> param_list;
+  for (const auto& param_it: this->param_map_) {
+    param_list.template emplace_back(param_it.second);
+  }
+  return param_list;
+}
+
+inline void ParameterMap::set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
+  this->validate_and_set_parameter(parameter);
+}
+
+inline void ParameterMap::set_parameters(
+    const std::list<std::shared_ptr<state_representation::ParameterInterface>>& parameters
+) {
+  for (const auto& param: parameters) {
+    this->set_parameter(param);
+  }
+}
+
+inline void ParameterMap::set_parameters(
+    const std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>>& parameters
+) {
+  for (const auto& param_it: parameters) {
+    this->set_parameter(param_it.second);
+  }
+}
+
+template<typename T>
+inline void ParameterMap::set_parameter_value(const std::string& name, const T& value) {
+  using namespace state_representation;
+  this->validate_and_set_parameter(std::make_shared<Parameter<T>>(Parameter<T>(name, value)));
+}
+
+inline void ParameterMap::assert_parameter_valid(
+    const std::shared_ptr<state_representation::ParameterInterface>& parameter
+) {
+  if (this->param_map_.at(parameter->get_name())->get_type() != parameter->get_type()) {
+    throw exceptions::InvalidParameterException(
+        "Parameter '" + parameter->get_name() + "' exists, but has unexpected type.");
+  }
+}
+
+inline void
+ParameterMap::validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
+  this->param_map_[parameter->get_name()] = parameter;
+}
+
+}


### PR DESCRIPTION
* Implement a ParameterMap base class that wraps an STL map
of named paramater interface pointers and provides access methods
to get, set and validate  parameters. This logic has been moved
out of IDynamicalSystem to enable re-usability

* Move InvalidParameterException to state_representation namespace

* Make validate_and_set_parameter method not pure virtual, and by
default allow the map to be modified by any and all set_parameter calls

* Rename class property param_map_ to parameters_

--- 

Motivation: the logic added by the dynamical systems (re)factory to handle getting, setting and validating parameters of a class is very nice, and should be reusable for other similar classes. For example, a controller factory should operate in a similar way.