### PR TITLE
Add CartesianAcceleration class in state representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Release Versions:
 - Add user sshd configuration and user 'developer' in base Dockerfile 
   and update all the Dockerfiles and scripts (#244, #246)
 - Add ParameterMap base class (#247)
+- Add CartesianAcceleration class in state representation (#248)
 
 ### Pending TODOs for the next release
 

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -42,7 +42,7 @@ void cartesian_state_variable(py::module_& m) {
       .value("TWIST", CartesianStateVariable::TWIST)
       .value("LINEAR_ACCELERATION", CartesianStateVariable::LINEAR_ACCELERATION)
       .value("ANGULAR_ACCELERATION", CartesianStateVariable::ANGULAR_ACCELERATION)
-      .value("ACCELERATIONS", CartesianStateVariable::ACCELERATIONS)
+      .value("ACCELERATION", CartesianStateVariable::ACCELERATION)
       .value("FORCE", CartesianStateVariable::FORCE)
       .value("TORQUE", CartesianStateVariable::TORQUE)
       .value("WRENCH", CartesianStateVariable::WRENCH)
@@ -71,8 +71,8 @@ void cartesian_state(py::module_& m) {
   c.def("get_twist", &CartesianState::get_twist, "Getter of the 6d twist from linear and angular velocity attributes");
 
   c.def("get_linear_acceleration", &CartesianState::get_linear_acceleration, "Getter of the linear acceleration attribute");
-  c.def("get_angular_acceleration", &CartesianState::get_angular_acceleration, "Getter of the linear acceleration attribute");
-  c.def("get_accelerations", &CartesianState::get_accelerations, "Getter of the 6d accelerations from linear and angular acceleration attributes");
+  c.def("get_angular_acceleration", &CartesianState::get_angular_acceleration, "Getter of the angular acceleration attribute");
+  c.def("get_acceleration", &CartesianState::get_acceleration, "Getter of the 6d acceleration from linear and angular acceleration attributes");
 
   c.def("get_force", &CartesianState::get_force, "Getter of the force attribute");
   c.def("get_torque", &CartesianState::get_torque, "Getter of the torque attribute");
@@ -91,8 +91,8 @@ void cartesian_state(py::module_& m) {
   c.def("set_twist", &CartesianState::set_twist, "Setter of the linear and angular velocities from a 6d twist vector");
 
   c.def("set_linear_acceleration", &CartesianState::set_linear_acceleration, "Setter of the linear acceleration attribute");
-  c.def("set_angular_acceleration", &CartesianState::set_angular_acceleration, "Setter of the linear acceleration attribute");
-  c.def("set_accelerations", &CartesianState::set_accelerations, "Setter of the linear and angular accelerations from a 6d acceleration vector");
+  c.def("set_angular_acceleration", &CartesianState::set_angular_acceleration, "Setter of the angular acceleration attribute");
+  c.def("set_acceleration", &CartesianState::set_acceleration, "Setter of the linear and angular acceleration from a 6d acceleration vector");
 
   c.def("set_force", &CartesianState::set_force, "Setter of the force attribute");
   c.def("set_torque", &CartesianState::set_torque, "Setter of the torque attribute");
@@ -168,7 +168,7 @@ void cartesian_pose(py::module_& m) {
       "twist",
       "linear_acceleration",
       "angular_acceleration",
-      "accelerations",
+      "acceleration",
       "force",
       "torque",
       "wrench"
@@ -218,7 +218,6 @@ void cartesian_pose(py::module_& m) {
   });
 }
 
-
 void cartesian_twist(py::module_& m) {
   py::class_<CartesianTwist, CartesianState> c(m, "CartesianTwist");
 
@@ -241,7 +240,7 @@ void cartesian_twist(py::module_& m) {
       "pose",
       "linear_acceleration",
       "angular_acceleration",
-      "accelerations",
+      "acceleration",
       "force",
       "torque",
       "wrench"
@@ -316,7 +315,7 @@ void cartesian_wrench(py::module_& m) {
       "twist",
       "linear_acceleration",
       "angular_acceleration",
-      "accelerations",
+      "acceleration",
   };
 
   for (const std::string& attr : deleted_attributes) {

--- a/python/test/space/test_cartesian_state.py
+++ b/python/test/space/test_cartesian_state.py
@@ -17,7 +17,7 @@ CARTESIAN_STATE_METHOD_EXPECTS = [
     'data',
     'set_data',
     'dist',
-    'get_accelerations',
+    'get_acceleration',
     'get_angular_acceleration',
     'get_angular_velocity',
     'get_force',
@@ -43,7 +43,7 @@ CARTESIAN_STATE_METHOD_EXPECTS = [
     'normalized',
     'norms',
     'reset_timestamp',
-    'set_accelerations',
+    'set_acceleration',
     'set_angular_acceleration',
     'set_angular_velocity',
     'set_empty',
@@ -131,7 +131,7 @@ class TestCartesianState(unittest.TestCase):
         self.assertAlmostEqual(np.linalg.norm(identity.get_orientation()), 1)
         self.assertAlmostEqual(identity.get_orientation()[0], 1)
         self.assertAlmostEqual(np.linalg.norm(identity.get_twist()), 0)
-        self.assertAlmostEqual(np.linalg.norm(identity.get_accelerations()), 0)
+        self.assertAlmostEqual(np.linalg.norm(identity.get_acceleration()), 0)
         self.assertAlmostEqual(np.linalg.norm(identity.get_wrench()), 0)
 
     def test_random_initialization(self):
@@ -142,7 +142,7 @@ class TestCartesianState(unittest.TestCase):
         self.assertAlmostEqual(np.linalg.norm(random.get_orientation()), 1)
         [self.assertTrue(random.get_orientation()[i] != 0) for i in range(4)]
         self.assertTrue(np.linalg.norm(random.get_twist()) > 0)
-        self.assertTrue(np.linalg.norm(random.get_accelerations()) > 0)
+        self.assertTrue(np.linalg.norm(random.get_acceleration()) > 0)
         self.assertTrue(np.linalg.norm(random.get_wrench()) > 0)
 
     def test_copy(self):
@@ -230,9 +230,9 @@ class TestCartesianState(unittest.TestCase):
         angular_acceleration = np.random.rand(3)
         cs.set_angular_acceleration(angular_acceleration)
         assert_array_almost_equal(cs.get_angular_acceleration(), angular_acceleration)
-        accelerations = np.random.rand(6)
-        cs.set_accelerations(accelerations)
-        assert_array_almost_equal(cs.get_accelerations(), accelerations)
+        acceleration = np.random.rand(6)
+        cs.set_acceleration(acceleration)
+        assert_array_almost_equal(cs.get_acceleration(), acceleration)
 
         # wrench
         force = np.random.rand(3)
@@ -273,7 +273,7 @@ class TestCartesianState(unittest.TestCase):
     def test_get_set_data(self):
         cs1 = CartesianState().Identity("test")
         cs2 = CartesianState().Random("test")
-        concatenated_state = np.hstack((cs1.get_pose(), cs1.get_twist(), cs1.get_accelerations(), cs1.get_wrench()))
+        concatenated_state = np.hstack((cs1.get_pose(), cs1.get_twist(), cs1.get_acceleration(), cs1.get_wrench()))
         assert_array_almost_equal(cs1.data(), concatenated_state)
         assert_array_almost_equal(cs1.array(), concatenated_state)
 
@@ -307,8 +307,8 @@ class TestCartesianState(unittest.TestCase):
                              CartesianStateVariable.LINEAR_ACCELERATION, 3)
         self.clamping_helper(state, state.get_angular_acceleration, state.set_angular_acceleration,
                              CartesianStateVariable.ANGULAR_ACCELERATION, 3)
-        self.clamping_helper(state, state.get_accelerations, state.set_accelerations,
-                             CartesianStateVariable.ACCELERATIONS, 6)
+        self.clamping_helper(state, state.get_acceleration, state.set_acceleration,
+                             CartesianStateVariable.ACCELERATION, 6)
         self.clamping_helper(state, state.get_force, state.set_force, CartesianStateVariable.FORCE, 3)
         self.clamping_helper(state, state.get_torque, state.set_torque, CartesianStateVariable.TORQUE, 3)
         self.clamping_helper(state, state.get_wrench, state.set_wrench, CartesianStateVariable.WRENCH, 6)
@@ -369,7 +369,7 @@ class TestCartesianState(unittest.TestCase):
         self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.ORIENTATION), orient_dist)
         self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.POSE), pos_dist + orient_dist)
         self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.TWIST), lin_vel_dist + ang_vel_dist)
-        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.ACCELERATIONS), lin_acc_dist + ang_acc_dist)
+        self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.ACCELERATION), lin_acc_dist + ang_acc_dist)
         self.assertAlmostEqual(cs1.dist(cs3, CartesianStateVariable.WRENCH), force_dist + torque_dist)
         self.assertAlmostEqual(cs1.dist(cs3), cs3.dist(cs1, CartesianStateVariable.ALL))
 
@@ -386,7 +386,7 @@ class TestCartesianState(unittest.TestCase):
         assert_array_almost_equal(csum.get_position(), cs1.get_position() + cs2.get_position())
         # TODO orientation sum
         assert_array_almost_equal(csum.get_twist(), cs1.get_twist() + cs2.get_twist())
-        assert_array_almost_equal(csum.get_accelerations(), cs1.get_accelerations() + cs2.get_accelerations())
+        assert_array_almost_equal(csum.get_acceleration(), cs1.get_acceleration() + cs2.get_acceleration())
         assert_array_almost_equal(csum.get_wrench(), cs1.get_wrench() + cs2.get_wrench())
 
         cs1 += cs2
@@ -406,7 +406,7 @@ class TestCartesianState(unittest.TestCase):
         assert_array_almost_equal(cdiff.get_position(), cs1.get_position() - cs2.get_position())
         # TODO orientation diff
         assert_array_almost_equal(cdiff.get_twist(), cs1.get_twist() - cs2.get_twist())
-        assert_array_almost_equal(cdiff.get_accelerations(), cs1.get_accelerations() - cs2.get_accelerations())
+        assert_array_almost_equal(cdiff.get_acceleration(), cs1.get_acceleration() - cs2.get_acceleration())
         assert_array_almost_equal(cdiff.get_wrench(), cs1.get_wrench() - cs2.get_wrench())
 
         cs1 -= cs2
@@ -421,7 +421,7 @@ class TestCartesianState(unittest.TestCase):
         assert_array_almost_equal(cscaled.get_position(), scalar * cs.get_position())
         # TODO orientation mult
         assert_array_almost_equal(cscaled.get_twist(), scalar * cs.get_twist())
-        assert_array_almost_equal(cscaled.get_accelerations(), scalar * cs.get_accelerations())
+        assert_array_almost_equal(cscaled.get_acceleration(), scalar * cs.get_acceleration())
         assert_array_almost_equal(cscaled.get_wrench(), scalar * cs.get_wrench())
 
         cs *= scalar
@@ -440,7 +440,7 @@ class TestCartesianState(unittest.TestCase):
         assert_array_almost_equal(cscaled.get_position(), cs.get_position() / scalar)
         # TODO orientation diff
         assert_array_almost_equal(cscaled.get_twist(), cs.get_twist() / scalar)
-        assert_array_almost_equal(cscaled.get_accelerations(), cs.get_accelerations() / scalar)
+        assert_array_almost_equal(cscaled.get_acceleration(), cs.get_acceleration() / scalar)
         assert_array_almost_equal(cscaled.get_wrench(), cs.get_wrench() / scalar)
 
         cs /= scalar

--- a/source/state_representation/CMakeLists.txt
+++ b/source/state_representation/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CORE_SOURCES
   src/space/cartesian/CartesianState.cpp
   src/space/cartesian/CartesianPose.cpp
   src/space/cartesian/CartesianTwist.cpp
+  src/space/cartesian/CartesianAcceleration.cpp
   src/space/cartesian/CartesianWrench.cpp
   src/robot/JointState.cpp
   src/robot/JointPositions.cpp

--- a/source/state_representation/README.md
+++ b/source/state_representation/README.md
@@ -116,7 +116,7 @@ i.e. if `wSa` has a `twist` or `acceleration` it will affect the state variables
 Full `CartesianState` can be difficult to handle as they contain all the dynamics of the frame when, sometime,
 you just want to express a `pose` without `twist`, `accelerations` or `wrench`.
 Therefore, extra classes representing only those specific state variables have been defined, `CartesianPose`,
-`CartesianTwist` and `CartesianWrench`.
+`CartesianTwist`, `CartesianAcceleration` and `CartesianWrench`.
 Effectively, they all extend from `CartesianState` hence they can be intertwined as will.
 
 ```cpp

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianAcceleration.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianAcceleration.hpp
@@ -1,0 +1,307 @@
+#pragma once
+
+#include "state_representation/space/cartesian/CartesianState.hpp"
+#include "state_representation/space/cartesian/CartesianTwist.hpp"
+
+namespace state_representation {
+class CartesianTwist;
+
+/**
+ * @class CartesianAcceleration
+ * @brief Class to define acceleration in cartesian space as 3D linear and angular acceleration vectors
+ */
+class CartesianAcceleration : public CartesianState {
+private:
+  using CartesianState::clamp_state_variable;
+
+public:
+  // delete inaccessible getter and setters
+  const Eigen::Vector3d& get_position() const = delete;
+  const Eigen::Quaterniond& get_orientation() const = delete;
+  Eigen::Vector4d get_orientation_coefficients() const = delete;
+  Eigen::Matrix<double, 7, 1> get_pose() const = delete;
+  Eigen::Matrix4d get_transformation_matrix() const = delete;
+  const Eigen::Vector3d& get_linear_velocity() const = delete;
+  const Eigen::Vector3d& get_angular_velocity() const = delete;
+  Eigen::Matrix<double, 6, 1> get_twist() const = delete;
+  const Eigen::Vector3d& get_force() const = delete;
+  const Eigen::Vector3d& get_torque() const = delete;
+  Eigen::Matrix<double, 6, 1> get_wrench() const = delete;
+  void set_position(const Eigen::Vector3d& position) = delete;
+  void set_position(const std::vector<double>& position) = delete;
+  void set_position(const double& x, const double& y, const double& z) = delete;
+  void set_orientation(const Eigen::Quaterniond& orientation) = delete;
+  void set_orientation(const Eigen::Vector4d& orientation) = delete;
+  void set_orientation(const std::vector<double>& orientation) = delete;
+  void set_pose(const Eigen::Vector3d& position, const Eigen::Quaterniond& orientation) = delete;
+  void set_pose(const Eigen::Matrix<double, 7, 1>& pose) = delete;
+  void set_pose(const std::vector<double>& pose) = delete;
+  void set_linear_velocity(const Eigen::Vector3d& linear_acceleration) = delete;
+  void set_angular_velocity(const Eigen::Vector3d& angular_acceleration) = delete;
+  void set_twist(const Eigen::Matrix<double, 6, 1>& acceleration) = delete;
+  void set_force(const Eigen::Vector3d& force) = delete;
+  void set_torque(const Eigen::Vector3d& torque) = delete;
+  void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;
+  CartesianState operator*=(const CartesianState& state) = delete;
+  CartesianState operator*(const CartesianState& state) = delete;
+  friend CartesianState operator*=(const CartesianState& state, const CartesianAcceleration& acceleration) = delete;
+
+  /**
+   * @brief Empty constructor
+   */
+  explicit CartesianAcceleration() = default;
+
+  /**
+   * @brief Constructor with name and reference frame provided
+   * @param name the name of the state
+   * @param reference the name of the reference frame
+   */
+  explicit CartesianAcceleration(const std::string& name, const std::string& reference = "world");
+
+  /**
+   * @brief Copy constructor
+   */
+  CartesianAcceleration(const CartesianAcceleration& acceleration);
+
+  /**
+   * @brief Copy constructor from a CartesianState
+   */
+  CartesianAcceleration(const CartesianState& state);
+
+  /**
+   * @brief Copy constructor from a CartesianTwist by considering that it is equivalent to dividing the twist by 1 second
+   */
+  CartesianAcceleration(const CartesianTwist& pose);
+
+  /**
+   * @brief Construct a CartesianAcceleration from a linear acceleration given as a vector.
+   */
+  explicit CartesianAcceleration(
+      const std::string& name, const Eigen::Vector3d& linear_acceleration, const std::string& reference = "world"
+  );
+
+  /**
+   * @brief Construct a CartesianAcceleration from a linear acceleration and angular acceleration given as vectors.
+   */
+  explicit CartesianAcceleration(
+      const std::string& name, const Eigen::Vector3d& linear_acceleration, const Eigen::Vector3d& angular_acceleration,
+      const std::string& reference = "world"
+  );
+
+  /**
+   * @brief Construct a CartesianAcceleration from a single 6d acceleration vector
+   */
+  explicit CartesianAcceleration(
+      const std::string& name, const Eigen::Matrix<double, 6, 1>& acceleration, const std::string& reference = "world"
+  );
+
+  /**
+   * @brief Constructor for the zero acceleration
+   * @param name the name of the state
+   * @param reference the name of the reference frame
+   * @return CartesianAcceleration with zero values
+   */
+  static CartesianAcceleration Zero(const std::string& name, const std::string& reference = "world");
+
+  /**
+   * @brief Constructor for a random acceleration
+   * @param name the name of the state
+   * @param reference the name of the reference frame
+   * @return CartesianAcceleration random acceleration
+   */
+  static CartesianAcceleration Random(const std::string& name, const std::string& reference = "world");
+
+  /**
+   * @brief Copy assignment operator that have to be defined to the custom assignment operator
+   * @param acceleration the acceleration with value to assign
+   * @return reference to the current acceleration with new values
+   */
+  CartesianAcceleration& operator=(const CartesianAcceleration& acceleration) = default;
+
+  /**
+   * @brief Overload the += operator
+   * @param acceleration CartesianAcceleration to add to
+   * @return the current CartesianAcceleration added the CartesianAcceleration given in argument
+   */
+  CartesianAcceleration& operator+=(const CartesianAcceleration& acceleration);
+
+  /**
+   * @brief Overload the + operator with an acceleration
+   * @param acceleration CartesianAcceleration to add to
+   * @return the current CartesianAcceleration added the CartesianAcceleration given in argument
+   */
+  CartesianAcceleration operator+(const CartesianAcceleration& acceleration) const;
+
+  /**
+   * @brief Overload the -= operator
+   * @param acceleration CartesianAcceleration to subtract
+   * @return the current CartesianAcceleration minus the CartesianAcceleration given in argument
+   */
+  CartesianAcceleration& operator-=(const CartesianAcceleration& acceleration);
+
+  /**
+   * @brief Overload the - operator with an acceleration
+   * @param acceleration CartesianAcceleration to subtract
+   * @return the current CartesianAcceleration minus the CartesianAcceleration given in argument
+   */
+  CartesianAcceleration operator-(const CartesianAcceleration& acceleration) const;
+
+  /**
+   * @brief Overload the *= operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianAcceleration multiplied by lambda
+   */
+  CartesianAcceleration& operator*=(double lambda);
+
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianAcceleration multiplied by lambda
+   */
+  CartesianAcceleration operator*(double lambda) const;
+
+  /**
+   * @brief Overload the /= operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianAcceleration divided by lambda
+   */
+  CartesianAcceleration& operator/=(double lambda);
+
+  /**
+   * @brief Overload the / operator with a scalar
+   * @param lambda the scalar to divide with
+   * @return the CartesianAcceleration divided by lambda
+   */
+  CartesianAcceleration operator/(double lambda) const;
+
+  /**
+   * @brief Overload the *= operator with a gain matrix
+   * @param lambda the matrix to multiply with
+   * @return the CartesianAcceleration multiplied by lambda
+   */
+  CartesianAcceleration& operator*=(const Eigen::Matrix<double, 6, 6>& lambda);
+
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the CartesianTwist corresponding to the twist over the time period
+   */
+  CartesianTwist operator*(const std::chrono::nanoseconds& dt) const;
+
+  /**
+   * @brief Clamp inplace the magnitude of the acceleration to the values in argument
+   * @param max_linear the maximum magnitude of the linear acceleration
+   * @param max_angular the maximum magnitude of the angular acceleration
+   * @param linear_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the linear acceleration will be set to 0
+   * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the angular acceleration will be set to 0
+   */
+  void clamp(double max_linear, double max_angular, double linear_noise_ratio = 0, double angular_noise_ratio = 0);
+
+  /**
+   * @brief Return the clamped twist
+   * @param max_linear the maximum magnitude of the linear acceleration
+   * @param max_angular the maximum magnitude of the angular acceleration
+   * @param noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the linear acceleration will be set to 0
+   * @param angular_noise_ratio if provided, this value will be used to apply a deadzone under which
+   * the angular acceleration will be set to 0
+   * @return the clamped acceleration
+   */
+  CartesianAcceleration clamped(
+      double max_linear, double max_angular, double noise_ratio = 0, double angular_noise_ratio = 0
+  ) const;
+
+  /**
+   * @brief Return a copy of the CartesianAcceleration
+   * @return the copy
+   */
+  CartesianAcceleration copy() const;
+
+  /**
+   * @brief Returns the acceleration data as an Eigen vector
+   * @return the acceleration data vector
+   */
+  Eigen::VectorXd data() const override;
+
+  /**
+   * @brief Set the acceleration data from an Eigen vector
+   * @param the acceleration data vector
+   */
+  void set_data(const Eigen::VectorXd& data) override;
+
+  /**
+   * @brief Set the acceleration data from a std vector
+   * @param the acceleration data vector
+   */
+  void set_data(const std::vector<double>& data) override;
+
+  /**
+   * @brief Compute the inverse of the current CartesianAcceleration
+   * @return the inverse corresponding to b_S_f (assuming this is f_S_b)
+   */
+  CartesianAcceleration inverse() const;
+
+  /**
+   * @brief Compute the norms of the state variable specified by the input type (default is full twist)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the norms of the state variables as a vector
+   */
+  std::vector<double>
+  norms(const CartesianStateVariable& state_variable_type = CartesianStateVariable::ACCELERATION) const override;
+
+  /**
+   * @brief Compute the normalized acceleration at the state variable given in argument (default is full acceleration)
+   * @param state_variable_type the type of state variable to compute the norms on
+   * @return the normalized acceleration
+   */
+  CartesianAcceleration
+  normalized(const CartesianStateVariable& state_variable_type = CartesianStateVariable::ACCELERATION) const;
+
+  /**
+   * @brief Overload the ostream operator for printing
+   * @param os the ostream to append the string representing the CartesianAcceleration to
+   * @param CartesianAcceleration the CartesianAcceleration to print
+   * @return the appended ostream
+   */
+  friend std::ostream& operator<<(std::ostream& os, const CartesianAcceleration& acceleration);
+
+  /**
+   * @brief Overload the * operator with a CartesianState
+   * @param state the state to multiply with
+   * @return the CartesianAcceleration provided multiplied by the state
+   */
+  friend CartesianAcceleration operator*(const CartesianState& state, const CartesianAcceleration& acceleration);
+
+  /**
+   * @brief Overload the * operator with a scalar
+   * @param lambda the scalar to multiply with
+   * @return the CartesianAcceleration provided multiplied by lambda
+   */
+  friend CartesianAcceleration operator*(double lambda, const CartesianAcceleration& acceleration);
+
+  /**
+   * @brief Overload the * operator with a gain matrix
+   * @param lambda the matrix to multiply with
+   * @return the CartesianAcceleration provided multiplied by lambda
+   */
+  friend CartesianAcceleration
+  operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianAcceleration& acceleration);
+
+  /**
+   * @brief Overload the * operator with a time period
+   * @param dt the time period to multiply with
+   * @return the CartesianTwist corresponding to the velocity over the time period
+   */
+  friend CartesianTwist operator*(const std::chrono::nanoseconds& dt, const CartesianAcceleration& acceleration);
+};
+
+inline std::vector<double> CartesianAcceleration::norms(const CartesianStateVariable& state_variable_type) const {
+  return CartesianState::norms(state_variable_type);
+}
+
+inline CartesianAcceleration CartesianAcceleration::normalized(const CartesianStateVariable& state_variable_type) const {
+  return CartesianState::normalized(state_variable_type);
+}
+}// namespace state_representation

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -2,10 +2,12 @@
 
 #include "state_representation/space/cartesian/CartesianState.hpp"
 #include "state_representation/space/cartesian/CartesianTwist.hpp"
+#include "state_representation/space/cartesian/CartesianAcceleration.hpp"
 #include "state_representation/space/cartesian/CartesianWrench.hpp"
 
 namespace state_representation {
 class CartesianTwist;
+class CartesianAcceleration;
 class CartesianWrench;
 
 /**
@@ -167,6 +169,13 @@ public:
    * @return the current CartesianPose multiplied by the CartesianTwist given in argument
    */
   CartesianTwist operator*(const CartesianTwist& twist) const;
+
+  /**
+   * @brief Overload the * operator
+   * @param acceleration CartesianAcceleration to multiply with
+   * @return the current CartesianPose multiplied by the CartesianAcceleration given in argument
+   */
+  CartesianAcceleration operator*(const CartesianAcceleration& acceleration) const;
 
   /**
    * @brief Overload the * operator

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianPose.hpp
@@ -23,7 +23,7 @@ public:
   Eigen::Matrix<double, 6, 1> get_twist() const = delete;
   const Eigen::Vector3d& get_linear_acceleration() const = delete;
   const Eigen::Vector3d& get_angular_acceleration() const = delete;
-  Eigen::Matrix<double, 6, 1> get_accelerations() const = delete;
+  Eigen::Matrix<double, 6, 1> get_acceleration() const = delete;
   const Eigen::Vector3d& get_force() const = delete;
   const Eigen::Vector3d& get_torque() const = delete;
   Eigen::Matrix<double, 6, 1> get_wrench() const = delete;
@@ -32,7 +32,7 @@ public:
   void set_twist(const Eigen::Matrix<double, 6, 1>& twist) = delete;
   void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
-  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+  void set_acceleration(const Eigen::Matrix<double, 6, 1>& acceleration) = delete;
   void set_force(const Eigen::Vector3d& force) = delete;
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianState.hpp
@@ -20,7 +20,7 @@ enum class CartesianStateVariable {
   TWIST,
   LINEAR_ACCELERATION,
   ANGULAR_ACCELERATION,
-  ACCELERATIONS,
+  ACCELERATION,
   FORCE,
   TORQUE,
   WRENCH,
@@ -62,21 +62,21 @@ private:
   void set_all_state_variables(const Eigen::VectorXd& new_values);
 
   /**
-   * @brief Set new_value in the provided state_variable (positions, velocities, accelerations or torques)
+   * @brief Set new_value in the provided state_variable (position, velocity, acceleration, force or torque)
    * @param state_variable the state variable to fill
    * @param new_value the new value of the state variable
    */
   void set_state_variable(Eigen::Vector3d& state_variable, const Eigen::Vector3d& new_value);
 
   /**
-   * @brief Set new_value in the provided state_variable (positions, velocities, accelerations or torques)
+   * @brief Set new_value in the provided state_variable (position, velocity, acceleration, force or torque)
    * @param state_variable the state variable to fill
    * @param new_value the new value of the state variable
    */
   void set_state_variable(Eigen::Vector3d& state_variable, const std::vector<double>& new_value);
 
   /**
-   * @brief Set new_value in the provided state_variable (twist, accelerations or wrench)
+   * @brief Set new_value in the provided state_variable (twist, acceleration or wrench)
    * @param linear_state_variable the linear part of the state variable to fill
    * @param angular_state_variable the angular part of the state variable to fill
    * @param new_value the new value of the state variable
@@ -87,7 +87,7 @@ private:
   );
 
   /**
-   * @brief Set new_value in the provided state_variable (twist, accelerations or wrench)
+   * @brief Set new_value in the provided state_variable (twist, acceleration or wrench)
    * @param linear_state_variable the linear part of the state variable to fill
    * @param angular_state_variable the angular part of the state variable to fill
    * @param new_value the new value of the state variable
@@ -217,7 +217,7 @@ public:
   /**
    * @brief Getter of the 6d acceleration from linear and angular acceleration attributes
    */
-  Eigen::Matrix<double, 6, 1> get_accelerations() const;
+  Eigen::Matrix<double, 6, 1> get_acceleration() const;
 
   /**
    * @brief Getter of the force attribute
@@ -315,9 +315,9 @@ public:
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration);
 
   /**
-   * @brief Setter of the linear and angular accelerations from a 6d acceleration vector
+   * @brief Setter of the linear and angular acceleration from a 6d acceleration vector
    */
-  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations);
+  void set_acceleration(const Eigen::Matrix<double, 6, 1>& acceleration);
 
   /**
    * @brief Setter of the force attribute
@@ -595,10 +595,10 @@ inline const Eigen::Vector3d& CartesianState::get_angular_acceleration() const {
   return this->angular_acceleration_;
 }
 
-inline Eigen::Matrix<double, 6, 1> CartesianState::get_accelerations() const {
-  Eigen::Matrix<double, 6, 1> accelerations;
-  accelerations << this->get_linear_acceleration(), this->get_angular_acceleration();
-  return accelerations;
+inline Eigen::Matrix<double, 6, 1> CartesianState::get_acceleration() const {
+  Eigen::Matrix<double, 6, 1> acceleration;
+  acceleration << this->get_linear_acceleration(), this->get_angular_acceleration();
+  return acceleration;
 }
 
 inline const Eigen::Vector3d& CartesianState::get_force() const {
@@ -641,8 +641,8 @@ inline Eigen::VectorXd CartesianState::get_state_variable(const CartesianStateVa
     case CartesianStateVariable::ANGULAR_ACCELERATION:
       return this->get_angular_acceleration();
 
-    case CartesianStateVariable::ACCELERATIONS:
-      return this->get_accelerations();
+    case CartesianStateVariable::ACCELERATION:
+      return this->get_acceleration();
 
     case CartesianStateVariable::FORCE:
       return this->get_force();
@@ -655,7 +655,7 @@ inline Eigen::VectorXd CartesianState::get_state_variable(const CartesianStateVa
 
     case CartesianStateVariable::ALL:
       Eigen::VectorXd all_fields(25);
-      all_fields << this->get_pose(), this->get_twist(), this->get_accelerations(), this->get_wrench();
+      all_fields << this->get_pose(), this->get_twist(), this->get_acceleration(), this->get_wrench();
       return all_fields;
   }
   // this never goes here but is compulsory to avoid a warning
@@ -669,7 +669,7 @@ inline void CartesianState::set_all_state_variables(const Eigen::VectorXd& new_v
   }
   this->set_pose(new_values.segment(0, 7));
   this->set_twist(new_values.segment(7, 6));
-  this->set_accelerations(new_values.segment(13, 6));
+  this->set_acceleration(new_values.segment(13, 6));
   this->set_wrench(new_values.segment(19, 6));
 }
 
@@ -764,8 +764,8 @@ inline void CartesianState::set_angular_acceleration(const Eigen::Vector3d& angu
   this->set_state_variable(this->angular_acceleration_, angular_acceleration);
 }
 
-inline void CartesianState::set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) {
-  this->set_state_variable(this->linear_acceleration_, this->angular_acceleration_, accelerations);
+inline void CartesianState::set_acceleration(const Eigen::Matrix<double, 6, 1>& acceleration) {
+  this->set_state_variable(this->linear_acceleration_, this->angular_acceleration_, acceleration);
 }
 
 inline void CartesianState::set_force(const Eigen::Vector3d& force) {
@@ -816,8 +816,8 @@ inline void CartesianState::set_state_variable(
       this->set_angular_acceleration(new_value);
       break;
 
-    case CartesianStateVariable::ACCELERATIONS:
-      this->set_accelerations(new_value);
+    case CartesianStateVariable::ACCELERATION:
+      this->set_acceleration(new_value);
       break;
 
     case CartesianStateVariable::FORCE:
@@ -835,7 +835,7 @@ inline void CartesianState::set_state_variable(
     case CartesianStateVariable::ALL:
       this->set_pose(new_value.segment(0, 7));
       this->set_twist(new_value.segment(7, 6));
-      this->set_accelerations(new_value.segment(13, 6));
+      this->set_acceleration(new_value.segment(13, 6));
       this->set_wrench(new_value.segment(19, 6));
       break;
   }

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -25,7 +25,7 @@ public:
   Eigen::Matrix4d get_transformation_matrix() const = delete;
   const Eigen::Vector3d& get_linear_acceleration() const = delete;
   const Eigen::Vector3d& get_angular_acceleration() const = delete;
-  Eigen::Matrix<double, 6, 1> get_accelerations() const = delete;
+  Eigen::Matrix<double, 6, 1> get_acceleration() const = delete;
   const Eigen::Vector3d& get_force() const = delete;
   const Eigen::Vector3d& get_torque() const = delete;
   Eigen::Matrix<double, 6, 1> get_wrench() const = delete;
@@ -40,7 +40,7 @@ public:
   void set_pose(const std::vector<double>& pose) = delete;
   void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
-  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+  void set_acceleration(const Eigen::Matrix<double, 6, 1>& acceleration) = delete;
   void set_force(const Eigen::Vector3d& force) = delete;
   void set_torque(const Eigen::Vector3d& torque) = delete;
   void set_wrench(const Eigen::Matrix<double, 6, 1>& wrench) = delete;

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianTwist.hpp
@@ -2,11 +2,11 @@
 
 #include "state_representation/space/cartesian/CartesianState.hpp"
 #include "state_representation/space/cartesian/CartesianPose.hpp"
-#include "state_representation/space/cartesian/CartesianWrench.hpp"
+#include "state_representation/space/cartesian/CartesianAcceleration.hpp"
 
 namespace state_representation {
 class CartesianPose;
-class CartesianWrench;
+class CartesianAcceleration;
 
 /**
  * @class CartesianTwist
@@ -74,6 +74,11 @@ public:
    * @brief Copy constructor from a CartesianPose by considering that it is equivalent to dividing the pose by 1 second
    */
   CartesianTwist(const CartesianPose& pose);
+
+  /**
+   * @brief Copy constructor from a CartesianAcceleration by considering that it is a twist over 1 second
+   */
+  CartesianTwist(const CartesianAcceleration& acceleration);
 
   /**
    * @brief Construct a CartesianTwist from a linear velocity given as a vector.
@@ -189,6 +194,13 @@ public:
    * @return the CartesianPose corresponding to the displacement over the time period
    */
   CartesianPose operator*(const std::chrono::nanoseconds& dt) const;
+
+  /**
+   * @brief Overload the / operator with a time period
+   * @param dt the time period to divide by
+   * @return the corresponding CartesianAcceleration
+   */
+  CartesianAcceleration operator/(const std::chrono::nanoseconds& dt) const;
 
   /**
    * @brief Clamp inplace the magnitude of the twist to the values in argument

--- a/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
+++ b/source/state_representation/include/state_representation/space/cartesian/CartesianWrench.hpp
@@ -27,7 +27,7 @@ public:
   Eigen::Matrix4d get_transformation_matrix() const = delete;
   const Eigen::Vector3d& get_linear_acceleration() const = delete;
   const Eigen::Vector3d& get_angular_acceleration() const = delete;
-  Eigen::Matrix<double, 6, 1> get_accelerations() const = delete;
+  Eigen::Matrix<double, 6, 1> get_acceleration() const = delete;
   void set_position(const Eigen::Vector3d& position) = delete;
   void set_position(const std::vector<double>& position) = delete;
   void set_position(const double& x, const double& y, const double& z) = delete;
@@ -42,7 +42,7 @@ public:
   void set_twist(const Eigen::Matrix<double, 6, 1>& twist) = delete;
   void set_linear_acceleration(const Eigen::Vector3d& linear_acceleration) = delete;
   void set_angular_acceleration(const Eigen::Vector3d& angular_acceleration) = delete;
-  void set_accelerations(const Eigen::Matrix<double, 6, 1>& accelerations) = delete;
+  void set_acceleration(const Eigen::Matrix<double, 6, 1>& acceleration) = delete;
   CartesianState operator*=(const CartesianState& state) = delete;
   CartesianState operator*(const CartesianState& state) = delete;
   friend CartesianState operator*=(const CartesianState& state, const CartesianWrench& wrench) = delete;

--- a/source/state_representation/src/space/cartesian/CartesianAcceleration.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianAcceleration.cpp
@@ -1,0 +1,190 @@
+#include "state_representation/space/cartesian/CartesianAcceleration.hpp"
+#include "state_representation/exceptions/EmptyStateException.hpp"
+
+using namespace state_representation::exceptions;
+
+namespace state_representation {
+CartesianAcceleration::CartesianAcceleration(const std::string& name, const std::string& reference) :
+    CartesianState(name, reference) {}
+
+CartesianAcceleration::CartesianAcceleration(
+    const std::string& name, const Eigen::Vector3d& linear_acceleration, const std::string& reference
+) : CartesianState(name, reference) {
+  this->set_linear_acceleration(linear_acceleration);
+}
+
+CartesianAcceleration::CartesianAcceleration(
+    const std::string& name, const Eigen::Vector3d& linear_acceleration, const Eigen::Vector3d& angular_acceleration,
+    const std::string& reference
+) : CartesianState(name, reference) {
+  this->set_linear_acceleration(linear_acceleration);
+  this->set_angular_acceleration(angular_acceleration);
+}
+
+CartesianAcceleration::CartesianAcceleration(
+    const std::string& name, const Eigen::Matrix<double, 6, 1>& acceleration, const std::string& reference
+) : CartesianState(name, reference) {
+  this->set_acceleration(acceleration);
+}
+
+CartesianAcceleration::CartesianAcceleration(const CartesianState& state) : CartesianState(state) {
+  // set all the state variables to 0 except linear and angular velocities
+  this->set_zero();
+  this->set_acceleration(state.get_acceleration());
+  this->set_empty(state.is_empty());
+}
+
+CartesianAcceleration::CartesianAcceleration(const CartesianAcceleration& acceleration) :
+    CartesianAcceleration(static_cast<const CartesianState&>(acceleration)) {}
+
+CartesianAcceleration::CartesianAcceleration(const CartesianTwist& twist) : CartesianAcceleration(twist / std::chrono::seconds(1)) {}
+
+CartesianAcceleration CartesianAcceleration::Zero(const std::string& name, const std::string& reference) {
+  return CartesianState::Identity(name, reference);
+}
+
+CartesianAcceleration CartesianAcceleration::Random(const std::string& name, const std::string& reference) {
+  // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
+  Eigen::Matrix<double, 6, 1> random = Eigen::Matrix<double, 6, 1>::Random();
+  return CartesianTwist(name, random, reference);
+}
+
+CartesianAcceleration& CartesianAcceleration::operator+=(const CartesianAcceleration& acceleration) {
+  this->CartesianState::operator+=(acceleration);
+  return (*this);
+}
+
+CartesianAcceleration CartesianAcceleration::operator+(const CartesianAcceleration& acceleration) const {
+  return this->CartesianState::operator+(acceleration);
+}
+
+CartesianAcceleration& CartesianAcceleration::operator-=(const CartesianAcceleration& acceleration) {
+  this->CartesianState::operator-=(acceleration);
+  return (*this);
+}
+
+CartesianAcceleration CartesianAcceleration::operator-(const CartesianAcceleration& acceleration) const {
+  return this->CartesianState::operator-(acceleration);
+}
+
+CartesianAcceleration& CartesianAcceleration::operator*=(double lambda) {
+  this->CartesianState::operator*=(lambda);
+  return (*this);
+}
+
+CartesianAcceleration CartesianAcceleration::operator*(double lambda) const {
+  return this->CartesianState::operator*(lambda);
+}
+
+CartesianAcceleration& CartesianAcceleration::operator/=(double lambda) {
+  this->CartesianState::operator/=(lambda);
+  return (*this);
+}
+
+CartesianAcceleration CartesianAcceleration::operator/(double lambda) const {
+  return this->CartesianState::operator/(lambda);
+}
+
+CartesianAcceleration& CartesianAcceleration::operator*=(const Eigen::Matrix<double, 6, 6>& lambda) {
+  // sanity check
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  // operation
+  this->set_linear_acceleration(lambda.block<3, 3>(0, 0) * this->get_linear_acceleration());
+  this->set_angular_acceleration(lambda.block<3, 3>(3, 3) * this->get_angular_acceleration());
+  return (*this);
+}
+
+CartesianTwist CartesianAcceleration::operator*(const std::chrono::nanoseconds& dt) const {
+  // sanity check
+  if (this->is_empty()) {
+    throw EmptyStateException(this->get_name() + " state is empty");
+  }
+  // operations
+  CartesianTwist twist(this->get_name(), this->get_reference_frame());
+  // convert the period to a double with the second as reference
+  double period = dt.count();
+  period /= 1e9;
+  // convert the acceleration into a twist
+  twist.set_linear_velocity(period * this->get_linear_acceleration());
+  twist.set_angular_velocity(period * this->get_angular_acceleration());
+  return twist;
+}
+
+void CartesianAcceleration::clamp(
+    double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio
+) {
+  // clamp linear
+  this->clamp_state_variable(max_linear, CartesianStateVariable::LINEAR_ACCELERATION, linear_noise_ratio);
+  // clamp angular
+  this->clamp_state_variable(max_angular, CartesianStateVariable::ANGULAR_ACCELERATION, angular_noise_ratio);
+}
+
+CartesianAcceleration CartesianAcceleration::clamped(
+    double max_linear, double max_angular, double linear_noise_ratio, double angular_noise_ratio
+) const {
+  CartesianAcceleration result(*this);
+  result.clamp(max_linear, max_angular, linear_noise_ratio, angular_noise_ratio);
+  return result;
+}
+
+CartesianAcceleration CartesianAcceleration::copy() const {
+  CartesianAcceleration result(*this);
+  return result;
+}
+
+Eigen::VectorXd CartesianAcceleration::data() const {
+  return this->get_acceleration();
+}
+
+void CartesianAcceleration::set_data(const Eigen::VectorXd& data) {
+  if (data.size() != 6) {
+    throw IncompatibleSizeException(
+        "Input is of incorrect size: expected 6, given " + std::to_string(data.size()));
+  }
+  this->set_acceleration(data);
+}
+
+void CartesianAcceleration::set_data(const std::vector<double>& data) {
+  this->set_data(Eigen::VectorXd::Map(data.data(), data.size()));
+}
+
+CartesianAcceleration CartesianAcceleration::inverse() const {
+  return this->CartesianState::inverse();
+}
+
+std::ostream& operator<<(std::ostream& os, const CartesianAcceleration& acceleration) {
+  if (acceleration.is_empty()) {
+    os << "Empty CartesianAcceleration";
+  } else {
+    os << acceleration.get_name() << " CartesianTwist expressed in " << acceleration.get_reference_frame() << " frame"
+       << std::endl;
+    os << "linear_velocity: (" << acceleration.get_linear_acceleration()(0) << ", ";
+    os << acceleration.get_linear_acceleration()(1) << ", ";
+    os << acceleration.get_linear_acceleration()(2) << ")" << std::endl;
+    os << "angular_velocity: (" << acceleration.get_angular_acceleration()(0) << ", ";
+    os << acceleration.get_angular_acceleration()(1) << ", ";
+    os << acceleration.get_angular_acceleration()(2) << ")";
+  }
+  return os;
+}
+
+CartesianAcceleration operator*(const CartesianState& state, const CartesianAcceleration& acceleration) {
+  return state.operator*(acceleration);
+}
+
+CartesianAcceleration operator*(double lambda, const CartesianAcceleration& acceleration) {
+  return acceleration * lambda;
+}
+
+CartesianAcceleration operator*(const Eigen::Matrix<double, 6, 6>& lambda, const CartesianAcceleration& acceleration) {
+  CartesianAcceleration result(acceleration);
+  result *= lambda;
+  return result;
+}
+
+CartesianTwist operator*(const std::chrono::nanoseconds& dt, const CartesianAcceleration& acceleration) {
+  return acceleration * dt;
+}
+}// namespace state_representation

--- a/source/state_representation/src/space/cartesian/CartesianPose.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianPose.cpp
@@ -72,6 +72,10 @@ CartesianTwist CartesianPose::operator*(const CartesianTwist& twist) const {
   return this->CartesianState::operator*(twist);
 }
 
+CartesianAcceleration CartesianPose::operator*(const CartesianAcceleration& acceleration) const {
+  return this->CartesianState::operator*(acceleration);
+}
+
 CartesianWrench CartesianPose::operator*(const CartesianWrench& wrench) const {
   return this->CartesianState::operator*(wrench);
 }

--- a/source/state_representation/src/space/cartesian/CartesianState.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianState.cpp
@@ -58,7 +58,7 @@ CartesianState& CartesianState::operator*=(double lambda) {
   this->set_orientation(math_tools::exp(w, lambda / 2.));
   // calculate the other vectors normally
   this->set_twist(lambda * this->get_twist());
-  this->set_accelerations(lambda * this->get_accelerations());
+  this->set_acceleration(lambda * this->get_acceleration());
   this->set_wrench(lambda * this->get_wrench());
   return (*this);
 }
@@ -173,8 +173,8 @@ CartesianState& CartesianState::operator+=(const CartesianState& state) {
   this->set_orientation(this->get_orientation() * orientation);
   // operation on twist
   this->set_twist(this->get_twist() + state.get_twist());
-  // operation on accelerations
-  this->set_accelerations(this->get_accelerations() + state.get_accelerations());
+  // operation on acceleration
+  this->set_acceleration(this->get_acceleration() + state.get_acceleration());
   // operation on wrench
   this->set_wrench(this->get_wrench() + state.get_wrench());
   return (*this);
@@ -205,8 +205,8 @@ CartesianState& CartesianState::operator-=(const CartesianState& state) {
   this->set_orientation(this->get_orientation() * orientation.conjugate());
   // operation on twist
   this->set_twist(this->get_twist() - state.get_twist());
-  // operation on accelerations
-  this->set_accelerations(this->get_accelerations() - state.get_accelerations());
+  // operation on acceleration
+  this->set_acceleration(this->get_acceleration() - state.get_acceleration());
   // operation on wrench
   this->set_wrench(this->get_wrench() - state.get_wrench());
   return (*this);
@@ -301,12 +301,12 @@ double CartesianState::dist(const CartesianState& state, const CartesianStateVar
     result += (this->get_angular_velocity() - state.get_angular_velocity()).norm();
   }
   if (state_variable_type == CartesianStateVariable::LINEAR_ACCELERATION
-      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ACCELERATION
       || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_linear_acceleration() - state.get_linear_acceleration()).norm();
   }
   if (state_variable_type == CartesianStateVariable::ANGULAR_ACCELERATION
-      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ACCELERATION
       || state_variable_type == CartesianStateVariable::ALL) {
     result += (this->get_angular_acceleration() - state.get_angular_acceleration()).norm();
   }
@@ -341,12 +341,12 @@ std::vector<double> CartesianState::norms(const CartesianStateVariable& state_va
     norms.push_back(this->get_angular_velocity().norm());
   }
   if (state_variable_type == CartesianStateVariable::LINEAR_ACCELERATION
-      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ACCELERATION
       || state_variable_type == CartesianStateVariable::ALL) {
     norms.push_back(this->get_linear_acceleration().norm());
   }
   if (state_variable_type == CartesianStateVariable::ANGULAR_ACCELERATION
-      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ACCELERATION
       || state_variable_type == CartesianStateVariable::ALL) {
     norms.push_back(this->get_angular_acceleration().norm());
   }
@@ -380,12 +380,12 @@ void CartesianState::normalize(const CartesianStateVariable& state_variable_type
     this->angular_velocity_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::LINEAR_ACCELERATION
-      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ACCELERATION
       || state_variable_type == CartesianStateVariable::ALL) {
     this->linear_acceleration_.normalize();
   }
   if (state_variable_type == CartesianStateVariable::ANGULAR_ACCELERATION
-      || state_variable_type == CartesianStateVariable::ACCELERATIONS
+      || state_variable_type == CartesianStateVariable::ACCELERATION
       || state_variable_type == CartesianStateVariable::ALL) {
     this->angular_acceleration_.normalize();
   }

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_acceleration.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_acceleration.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include "state_representation/space/cartesian/CartesianAcceleration.hpp"
+
+using namespace state_representation;
+
+static void expect_only_acceleration(CartesianAcceleration& acceleration) {
+  EXPECT_EQ(static_cast<CartesianState&>(acceleration).get_position().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(acceleration).get_orientation().norm(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(acceleration).get_orientation().w(), 1);
+  EXPECT_EQ(static_cast<CartesianState&>(acceleration).get_twist().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(acceleration).get_wrench().norm(), 0);
+}
+
+TEST(CartesianAccelerationTest, RandomAccelerationInitialization) {
+  CartesianAcceleration random = CartesianAcceleration::Random("test");
+  EXPECT_GT(random.get_acceleration().norm(), 0);
+  expect_only_acceleration(random);
+}
+
+TEST(CartesianAccelerationTest, CopyTwist) {
+  CartesianAcceleration acc1 = CartesianAcceleration::Random("test");
+  CartesianAcceleration acc2(acc1);
+  EXPECT_EQ(acc1.get_name(), acc2.get_name());
+  EXPECT_EQ(acc1.get_reference_frame(), acc2.get_reference_frame());
+  EXPECT_EQ(acc1.data(), acc2.data());
+  expect_only_acceleration(acc2);
+
+  CartesianAcceleration acc3 = acc1;
+  EXPECT_EQ(acc1.get_name(), acc3.get_name());
+  EXPECT_EQ(acc1.get_reference_frame(), acc3.get_reference_frame());
+  EXPECT_EQ(acc1.data(), acc3.data());
+  expect_only_acceleration(acc3);
+
+  // try to change non pose variables prior to the copy, those should be discarded
+  static_cast<CartesianState&>(acc1).set_pose(Eigen::VectorXd::Random(7));
+  static_cast<CartesianState&>(acc1).set_acceleration(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(acc1).set_wrench(Eigen::VectorXd::Random(6));
+  CartesianAcceleration acc4 = acc1;
+  EXPECT_EQ(acc1.data(), acc4.data());
+  expect_only_acceleration(acc4);
+
+  // copy a state, only the pose variables should be non 0
+  CartesianAcceleration acc5 = CartesianState::Random("test");
+  expect_only_acceleration(acc5);
+
+  CartesianAcceleration acc6;
+  EXPECT_TRUE(acc6.is_empty());
+  CartesianAcceleration acc7 = acc6;
+  EXPECT_TRUE(acc7.is_empty());
+}
+
+TEST(CartesianAccelerationTest, SetData) {
+  CartesianAcceleration ca1 = CartesianAcceleration::Zero("test");
+  CartesianAcceleration ca2 = CartesianAcceleration::Random("test");
+  ca1.set_data(ca2.data());
+  EXPECT_TRUE(ca2.data().isApprox(ca2.data()));
+
+  auto acc_vec = ca2.to_std_vector();
+  ca1.set_data(acc_vec);
+  for (std::size_t j = 0; j < acc_vec.size(); ++j) {
+    EXPECT_FLOAT_EQ(acc_vec.at(j), ca1.data()(j));
+  }
+  std::vector<double> acc{1, 2, 3, 4, 5};
+  EXPECT_THROW(ca1.set_data(acc), exceptions::IncompatibleSizeException);
+}
+
+TEST(CartesianAccelerationTest, CartesianTwistToStdVector) {
+  CartesianAcceleration ca = CartesianAcceleration::Random("test");
+  std::vector<double> vec_data = ca.to_std_vector();
+  EXPECT_EQ(vec_data.size(), 6);
+  for (size_t i = 0; i < vec_data.size(); ++i) {
+    EXPECT_EQ(ca.data()(i), vec_data[i]);
+  }
+}
+
+TEST(CartesianAccelerationTest, TestVelocityClamping) {
+  CartesianAcceleration acc("test", Eigen::Vector3d(1, -2, 3), Eigen::Vector3d(1, 2, -3));
+  acc.clamp(1, 0.5);
+  EXPECT_LE(acc.get_linear_acceleration().norm(), 1);
+  EXPECT_LE(acc.get_angular_acceleration().norm(), 0.5);
+  acc *= 0.01;
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(acc.clamped(1, 0.5, 0.1, 0.1).get_linear_acceleration()(i), 0);
+    EXPECT_EQ(acc.clamped(1, 0.5, 0.1, 0.1).get_angular_acceleration()(i), 0);
+  }
+}
+
+TEST(CartesianAccelerationTest, TestTwistNorms) {
+  std::vector<double> norms;
+  double tolerance = 1e-4;
+  CartesianState cs = CartesianState::Random("cs");
+  // independent variables first
+  norms = cs.norms(CartesianStateVariable::LINEAR_ACCELERATION);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_linear_acceleration().norm(), tolerance);
+  norms = cs.norms(CartesianStateVariable::ANGULAR_ACCELERATION);
+  EXPECT_TRUE(norms.size() == 1);
+  EXPECT_NEAR(norms[0], cs.get_angular_acceleration().norm(), tolerance);
+  // then grouped by two
+  norms = cs.norms(CartesianStateVariable::ACCELERATION);
+  EXPECT_TRUE(norms.size() == 2);
+  EXPECT_NEAR(norms[0], cs.get_linear_acceleration().norm(), tolerance);
+  EXPECT_NEAR(norms[1], cs.get_angular_acceleration().norm(), tolerance);
+  // test with CartesianAcceleration default variable
+  CartesianAcceleration ct = CartesianTwist::Random("ct");
+  std::vector<double> twist_norms = ct.norms();
+  EXPECT_TRUE(twist_norms.size() == 2);
+  EXPECT_NEAR(twist_norms[0], ct.get_linear_acceleration().norm(), tolerance);
+  EXPECT_NEAR(twist_norms[1], ct.get_angular_acceleration().norm(), tolerance);
+}

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_pose.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_pose.cpp
@@ -7,7 +7,7 @@ using namespace state_representation;
 static void expect_only_pose(CartesianPose& pose) {
   EXPECT_EQ(static_cast<CartesianState&>(pose).get_orientation().norm(), 1);
   EXPECT_EQ(static_cast<CartesianState&>(pose).get_twist().norm(), 0);
-  EXPECT_EQ(static_cast<CartesianState&>(pose).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(pose).get_acceleration().norm(), 0);
   EXPECT_EQ(static_cast<CartesianState&>(pose).get_wrench().norm(), 0);
 }
 
@@ -61,7 +61,7 @@ TEST(CartesianPoseTest, CopyPose) {
 
   // try to change non pose variables prior to the copy, those should be discarded
   static_cast<CartesianState&>(pose1).set_twist(Eigen::VectorXd::Random(6));
-  static_cast<CartesianState&>(pose1).set_accelerations(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(pose1).set_acceleration(Eigen::VectorXd::Random(6));
   static_cast<CartesianState&>(pose1).set_wrench(Eigen::VectorXd::Random(6));
   CartesianPose pose4 = pose1;
   EXPECT_EQ(pose1.data(), pose4.data());

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_twist.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_twist.cpp
@@ -109,3 +109,24 @@ TEST(CartesianTwistTest, TestTwistNorms) {
   EXPECT_NEAR(twist_norms[0], ct.get_linear_velocity().norm(), tolerance);
   EXPECT_NEAR(twist_norms[1], ct.get_angular_velocity().norm(), tolerance);
 }
+
+TEST(CartesianTwistTest, TestVelocityToAcceleration) {
+  auto twist = CartesianTwist::Random("test");
+  std::chrono::seconds dt1(1);
+  std::chrono::milliseconds dt2(100);
+  auto res1 = twist / dt1;
+  EXPECT_EQ(res1.get_linear_acceleration(), twist.get_linear_velocity());
+  EXPECT_EQ(res1.get_angular_acceleration(), twist.get_angular_velocity());
+  auto res2 = twist / dt2;
+  EXPECT_TRUE(res2.get_linear_acceleration().isApprox(10 * twist.get_linear_velocity()));
+  EXPECT_TRUE(res2.get_angular_acceleration().isApprox(10 * twist.get_angular_velocity()));
+}
+
+TEST(CartesianTwistTest, TestImplicitConversion) {
+  CartesianAcceleration acc("test");
+  acc.set_linear_acceleration(Eigen::Vector3d(0.1, 0.1, 0.1));
+  acc.set_linear_acceleration(Eigen::Vector3d(M_PI, 0, 0));
+  CartesianTwist twist(acc);
+  EXPECT_EQ(twist.get_linear_velocity(), acc.get_linear_acceleration());
+  EXPECT_EQ(twist.get_angular_velocity(), acc.get_angular_acceleration());
+}

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_twist.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_twist.cpp
@@ -8,7 +8,7 @@ static void expect_only_twist(CartesianTwist& twist) {
   EXPECT_EQ(static_cast<CartesianState&>(twist).get_position().norm(), 0);
   EXPECT_EQ(static_cast<CartesianState&>(twist).get_orientation().norm(), 1);
   EXPECT_EQ(static_cast<CartesianState&>(twist).get_orientation().w(), 1);
-  EXPECT_EQ(static_cast<CartesianState&>(twist).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(twist).get_acceleration().norm(), 0);
   EXPECT_EQ(static_cast<CartesianState&>(twist).get_wrench().norm(), 0);
 }
 
@@ -34,7 +34,7 @@ TEST(CartesianTwistTest, CopyTwist) {
 
   // try to change non pose variables prior to the copy, those should be discarded
   static_cast<CartesianState&>(twist1).set_pose(Eigen::VectorXd::Random(7));
-  static_cast<CartesianState&>(twist1).set_accelerations(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(twist1).set_acceleration(Eigen::VectorXd::Random(6));
   static_cast<CartesianState&>(twist1).set_wrench(Eigen::VectorXd::Random(6));
   CartesianTwist twist4 = twist1;
   EXPECT_EQ(twist1.data(), twist4.data());

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_wrench.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_wrench.cpp
@@ -9,7 +9,7 @@ static void expect_only_wrench(CartesianWrench& wrench) {
   EXPECT_EQ(static_cast<CartesianState&>(wrench).get_orientation().norm(), 1);
   EXPECT_EQ(static_cast<CartesianState&>(wrench).get_orientation().w(), 1);
   EXPECT_EQ(static_cast<CartesianState&>(wrench).get_twist().norm(), 0);
-  EXPECT_EQ(static_cast<CartesianState&>(wrench).get_accelerations().norm(), 0);
+  EXPECT_EQ(static_cast<CartesianState&>(wrench).get_acceleration().norm(), 0);
 }
 
 TEST(CartesianWrenchTest, RandomWrenchInitialization) {
@@ -35,7 +35,7 @@ TEST(CartesianWrenchTest, CopyWrench) {
   // try to change non pose variables prior to the copy, those should be discarded
   static_cast<CartesianState&>(wrench1).set_pose(Eigen::VectorXd::Random(7));
   static_cast<CartesianState&>(wrench1).set_twist(Eigen::VectorXd::Random(6));
-  static_cast<CartesianState&>(wrench1).set_accelerations(Eigen::VectorXd::Random(6));
+  static_cast<CartesianState&>(wrench1).set_acceleration(Eigen::VectorXd::Random(6));
   CartesianWrench wrench4 = wrench1;
   EXPECT_EQ(wrench1.data(), wrench4.data());
   expect_only_wrench(wrench4);


### PR DESCRIPTION
Okay, adding the CartesianAcceleration here, review by commit recommended. Apart from the addition of `CartesianAcceleration.hpp` and `CartesianAcceleration.cpp` I also had to add some operators and constructors in CartesianTwist and CartesianPose. 