### PR TITLE
Update pybindings and clproto with CartesianAcceleration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Release Versions:
 - Add ParameterMap base class (#247)
 - Add CartesianAcceleration class in state representation (#248)
 - Relocate Jacobian and JointState family files to the 'space/' directory (#249)
-- Update pybindings and clproto with CartesianAcceleration (#249)
+- Update pybindings and clproto with CartesianAcceleration (#250)
 
 ### Pending TODOs for the next release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Release Versions:
 - Add ParameterMap base class (#247)
 - Add CartesianAcceleration class in state representation (#248)
 - Relocate Jacobian and JointState family files to the 'space/' directory (#249)
+- Update pybindings and clproto with CartesianAcceleration (#249)
 
 ### Pending TODOs for the next release
 

--- a/protocol/clproto_cpp/src/clproto.cpp
+++ b/protocol/clproto_cpp/src/clproto.cpp
@@ -382,7 +382,7 @@ bool decode(const std::string& msg, CartesianTwist& obj) {
 }
 
 /* ----------------------
- *     CartesianAcceleration
+ *  CartesianAcceleration
  * ---------------------- */
 template<>
 std::string encode<CartesianAcceleration>(const CartesianAcceleration& obj);

--- a/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
@@ -76,19 +76,19 @@ TEST(CartesianProtoTest, EncodeDecodeCartesianTwist) {
 }
 
 TEST(CartesianProtoTest, EncodeDecodeCartesianAcceleration) {
-auto send_state = CartesianAcceleration::Random("A", "B");
-std::string msg = clproto::encode(send_state);
-EXPECT_TRUE(clproto::is_valid(msg));
-EXPECT_TRUE(clproto::check_message_type(msg) == clproto::CARTESIAN_ACCELERATION_MESSAGE);
+  auto send_state = CartesianAcceleration::Random("A", "B");
+  std::string msg = clproto::encode(send_state);
+  EXPECT_TRUE(clproto::is_valid(msg));
+  EXPECT_TRUE(clproto::check_message_type(msg) == clproto::CARTESIAN_ACCELERATION_MESSAGE);
 
-CartesianAcceleration recv_state;
-EXPECT_NO_THROW(clproto::decode<CartesianAcceleration>(msg));
-EXPECT_TRUE(clproto::decode(msg, recv_state));
-EXPECT_FALSE(recv_state.is_empty());
+  CartesianAcceleration recv_state;
+  EXPECT_NO_THROW(clproto::decode<CartesianAcceleration>(msg));
+  EXPECT_TRUE(clproto::decode(msg, recv_state));
+  EXPECT_FALSE(recv_state.is_empty());
 
-EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
-EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
-EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
+  EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+  EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
+  EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
 }
 
 TEST(CartesianProtoTest, EncodeDecodeCartesianWrench) {
@@ -141,14 +141,14 @@ TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianTwist) {
 }
 
 TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianAcceleration) {
-CartesianAcceleration empty_state;
-EXPECT_TRUE(empty_state.is_empty());
-std::string msg;
-EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+  CartesianAcceleration empty_state;
+  EXPECT_TRUE(empty_state.is_empty());
+  std::string msg;
+  EXPECT_NO_THROW(msg = clproto::encode(empty_state));
 
-CartesianAcceleration recv_state;
-EXPECT_NO_THROW(recv_state = clproto::decode<CartesianAcceleration>(msg));
-EXPECT_TRUE(recv_state.is_empty());
+  CartesianAcceleration recv_state;
+  EXPECT_NO_THROW(recv_state = clproto::decode<CartesianAcceleration>(msg));
+  EXPECT_TRUE(recv_state.is_empty());
 }
 
 TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianWrench) {

--- a/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
+++ b/protocol/clproto_cpp/test/tests/test_cartesian_space_proto.cpp
@@ -4,6 +4,7 @@
 #include <state_representation/space/cartesian/CartesianState.hpp>
 #include <state_representation/space/cartesian/CartesianPose.hpp>
 #include <state_representation/space/cartesian/CartesianTwist.hpp>
+#include <state_representation/space/cartesian/CartesianAcceleration.hpp>
 #include <state_representation/space/cartesian/CartesianWrench.hpp>
 
 #include "clproto.h"
@@ -74,6 +75,22 @@ TEST(CartesianProtoTest, EncodeDecodeCartesianTwist) {
   EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
 }
 
+TEST(CartesianProtoTest, EncodeDecodeCartesianAcceleration) {
+auto send_state = CartesianAcceleration::Random("A", "B");
+std::string msg = clproto::encode(send_state);
+EXPECT_TRUE(clproto::is_valid(msg));
+EXPECT_TRUE(clproto::check_message_type(msg) == clproto::CARTESIAN_ACCELERATION_MESSAGE);
+
+CartesianAcceleration recv_state;
+EXPECT_NO_THROW(clproto::decode<CartesianAcceleration>(msg));
+EXPECT_TRUE(clproto::decode(msg, recv_state));
+EXPECT_FALSE(recv_state.is_empty());
+
+EXPECT_STREQ(send_state.get_name().c_str(), recv_state.get_name().c_str());
+EXPECT_STREQ(send_state.get_reference_frame().c_str(), recv_state.get_reference_frame().c_str());
+EXPECT_NEAR(send_state.dist(recv_state), 0, 1e-5);
+}
+
 TEST(CartesianProtoTest, EncodeDecodeCartesianWrench) {
   auto send_state = CartesianWrench::Random("A", "B");
   std::string msg = clproto::encode(send_state);
@@ -121,6 +138,17 @@ TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianTwist) {
   CartesianTwist recv_state;
   EXPECT_NO_THROW(recv_state = clproto::decode<CartesianTwist>(msg));
   EXPECT_TRUE(recv_state.is_empty());
+}
+
+TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianAcceleration) {
+CartesianAcceleration empty_state;
+EXPECT_TRUE(empty_state.is_empty());
+std::string msg;
+EXPECT_NO_THROW(msg = clproto::encode(empty_state));
+
+CartesianAcceleration recv_state;
+EXPECT_NO_THROW(recv_state = clproto::decode<CartesianAcceleration>(msg));
+EXPECT_TRUE(recv_state.is_empty());
 }
 
 TEST(CartesianProtoTest, EncodeDecodeEmptyCartesianWrench) {

--- a/python/README.md
+++ b/python/README.md
@@ -80,6 +80,7 @@ Bindings exist for the following modules, classes and methods:
   - `CartesianState`
   - `CartesianPose`
   - `CartesianTwist`
+  - `CartesianAcceleration`
   - `CartesianWrench`
   - `JointState`
   - `JointPositions`

--- a/python/source/state_representation/bind_cartesian_space.cpp
+++ b/python/source/state_representation/bind_cartesian_space.cpp
@@ -302,7 +302,7 @@ void cartesian_acceleration(py::module_& m) {
   c.def(py::init<const CartesianTwist&>(), "Copy constructor from a CartesianTwist by considering that it is equivalent to dividing the twist by 1 second", "twist"_a);
 
   c.def(py::init<const std::string&, const Eigen::Vector3d&, const std::string&>(), "Construct a CartesianAcceleration from a linear acceleration given as a vector.", "name"_a, "linear_acceleration"_a, "reference"_a=std::string("world"));
-  c.def(py::init<const std::string&, const Eigen::Vector3d&, const Eigen::Vector3d&, const std::string&>(), "Construct a CartesianAcceleration from a linear velocity and angular velocity given as vectors.", "name"_a, "linear_acceleration"_a, "angular_acceleration"_a, "reference"_a=std::string("world"));
+  c.def(py::init<const std::string&, const Eigen::Vector3d&, const Eigen::Vector3d&, const std::string&>(), "Construct a CartesianAcceleration from a linear acceleration and angular acceleration given as vectors.", "name"_a, "linear_acceleration"_a, "angular_acceleration"_a, "reference"_a=std::string("world"));
   c.def(py::init<const std::string&, const Eigen::Matrix<double, 6, 1>&, const std::string&>(), "Construct a CartesianAcceleration from a single 6d acceleration vector", "name"_a, "acceleration"_a, "reference"_a=std::string("world"));
 
   c.def_static("Zero", &CartesianAcceleration::Zero, "Constructor for the zero acceleration", "name"_a, "reference"_a=std::string("world"));

--- a/source/state_representation/src/space/cartesian/CartesianAcceleration.cpp
+++ b/source/state_representation/src/space/cartesian/CartesianAcceleration.cpp
@@ -46,7 +46,7 @@ CartesianAcceleration CartesianAcceleration::Zero(const std::string& name, const
 CartesianAcceleration CartesianAcceleration::Random(const std::string& name, const std::string& reference) {
   // separating in the two lines in needed to avoid compilation error due to ambiguous constructor call
   Eigen::Matrix<double, 6, 1> random = Eigen::Matrix<double, 6, 1>::Random();
-  return CartesianTwist(name, random, reference);
+  return CartesianAcceleration(name, random, reference);
 }
 
 CartesianAcceleration& CartesianAcceleration::operator+=(const CartesianAcceleration& acceleration) {

--- a/source/state_representation/test/tests/space/cartesian/test_cartesian_acceleration.cpp
+++ b/source/state_representation/test/tests/space/cartesian/test_cartesian_acceleration.cpp
@@ -18,7 +18,7 @@ TEST(CartesianAccelerationTest, RandomAccelerationInitialization) {
   expect_only_acceleration(random);
 }
 
-TEST(CartesianAccelerationTest, CopyTwist) {
+TEST(CartesianAccelerationTest, CopyAcceleration) {
   CartesianAcceleration acc1 = CartesianAcceleration::Random("test");
   CartesianAcceleration acc2(acc1);
   EXPECT_EQ(acc1.get_name(), acc2.get_name());
@@ -65,7 +65,7 @@ TEST(CartesianAccelerationTest, SetData) {
   EXPECT_THROW(ca1.set_data(acc), exceptions::IncompatibleSizeException);
 }
 
-TEST(CartesianAccelerationTest, CartesianTwistToStdVector) {
+TEST(CartesianAccelerationTest, CartesianAccelerationToStdVector) {
   CartesianAcceleration ca = CartesianAcceleration::Random("test");
   std::vector<double> vec_data = ca.to_std_vector();
   EXPECT_EQ(vec_data.size(), 6);
@@ -74,7 +74,7 @@ TEST(CartesianAccelerationTest, CartesianTwistToStdVector) {
   }
 }
 
-TEST(CartesianAccelerationTest, TestVelocityClamping) {
+TEST(CartesianAccelerationTest, TestAccelerationClamping) {
   CartesianAcceleration acc("test", Eigen::Vector3d(1, -2, 3), Eigen::Vector3d(1, 2, -3));
   acc.clamp(1, 0.5);
   EXPECT_LE(acc.get_linear_acceleration().norm(), 1);
@@ -86,7 +86,7 @@ TEST(CartesianAccelerationTest, TestVelocityClamping) {
   }
 }
 
-TEST(CartesianAccelerationTest, TestTwistNorms) {
+TEST(CartesianAccelerationTest, TestAccelerationNorms) {
   std::vector<double> norms;
   double tolerance = 1e-4;
   CartesianState cs = CartesianState::Random("cs");


### PR DESCRIPTION
Follow up PR on #248 to add the CartesianAcceleration in the clproto and pybindings.