### PR TITLE
Remove getter and setter for timestamp

### DIFF
--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -105,6 +105,11 @@ public:
   virtual void set_name(const std::string& name);
 
   /**
+   * @brief Getter of the time of last modification
+   */
+  const std::chrono::time_point<std::chrono::steady_clock>& get_epoch() const;
+
+  /**
    * @brief Check if the state is deprecated given a certain time delay
    * @param time_delay the time after which to consider the state as deprecated
    */

--- a/source/state_representation/include/state_representation/State.hpp
+++ b/source/state_representation/include/state_representation/State.hpp
@@ -90,17 +90,6 @@ public:
   void set_filled();
 
   /**
-   * @brief Getter of the timestamp attribute
-   */
-  const std::chrono::time_point<std::chrono::steady_clock>& get_timestamp() const;
-
-  /**
-   * @brief Setter of the timestamp attribute
-   * @param timepoint the new value for the timestamp
-   */
-  void set_timestamp(const std::chrono::time_point<std::chrono::steady_clock>& timepoint);
-
-  /**
    * @brief Reset the timestamp attribute to now
    */
   void reset_timestamp();

--- a/source/state_representation/src/State.cpp
+++ b/source/state_representation/src/State.cpp
@@ -37,6 +37,10 @@ void State::reset_timestamp() {
   this->timestamp_ = std::chrono::steady_clock::now();
 }
 
+const std::chrono::time_point<std::chrono::steady_clock>& State::get_epoch() const {
+  return this->timestamp_;
+}
+
 const std::string& State::get_name() const {
   return this->name_;
 }

--- a/source/state_representation/src/State.cpp
+++ b/source/state_representation/src/State.cpp
@@ -33,14 +33,6 @@ void State::set_filled() {
   this->reset_timestamp();
 }
 
-const std::chrono::time_point<std::chrono::steady_clock>& State::get_timestamp() const {
-  return this->timestamp_;
-}
-
-void State::set_timestamp(const std::chrono::time_point<std::chrono::steady_clock>& timepoint) {
-  this->timestamp_ = timepoint;
-}
-
 void State::reset_timestamp() {
   this->timestamp_ = std::chrono::steady_clock::now();
 }

--- a/source/state_representation/test/tests/test_state.cpp
+++ b/source/state_representation/test/tests/test_state.cpp
@@ -54,7 +54,7 @@ TEST(StateTest, Timestamp) {
   EXPECT_FALSE(state.is_deprecated(std::chrono::milliseconds(100)));
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
   EXPECT_TRUE(state.is_deprecated(std::chrono::milliseconds(100)));
-  state.set_timestamp(std::chrono::steady_clock::now());
+  state.reset_timestamp();
   EXPECT_FALSE(state.is_deprecated(std::chrono::milliseconds(100)));
 }
 


### PR DESCRIPTION
As discussed, we will refactor the timestamp management in state representation. The timestamp attribute represents - as it was before - the time since last modification. Therefore, we don't want the setter of that attribute anymore, and the getter should be renamed.

I propose here `get_epoch` but I'm not sure thats a good choice. Maybe the more verbose option `get_time_since_last_modification` or `get_time_since_modification` could be nice too.